### PR TITLE
[Style] #12 리딩챌린지 선택시 설명 텍스트 컬러 변경

### DIFF
--- a/lib/modules/reading_challenge/view/widgets/challenge_option_card.dart
+++ b/lib/modules/reading_challenge/view/widgets/challenge_option_card.dart
@@ -44,7 +44,7 @@ class ChallengeOptionCard extends StatelessWidget {
             const SizedBox(height: 4),
             Text(
               subtitle,
-              style: AppTexts.b8.copyWith(color: ColorName.g3),
+              style: AppTexts.b8.copyWith(color: selected ? ColorName.g2 : ColorName.g3),
             ),
           ],
         ),


### PR DESCRIPTION
Fixes #12 

**변경사항**
- selected에 따라 subTitle  text color 변경


**스크린샷**

| Before | After |
|-------------------|-------------------|
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/d69e4c60-cf83-4ec3-b2b5-aaad156f8222" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/124b397f-c2c6-4508-b7a5-0dc0c99ce392" /> |