### PR TITLE
[Feature] #13 "읽던 책 읽기"에 책 검색 input 추가

### DIFF
--- a/lib/common/router/router.dart
+++ b/lib/common/router/router.dart
@@ -251,7 +251,7 @@ GoRouter router(Ref ref) {
                     path: 'continue-list',
                     parentNavigatorKey: rootNavigatorKey,
                     builder: (context, state) {
-                      return const OngoingChallengeListScreen();
+                      return OngoingChallengeListScreen();
                     },
                   ),
                   GoRoute(

--- a/lib/modules/book_pick/view/screens/book_pick_search_screen.dart
+++ b/lib/modules/book_pick/view/screens/book_pick_search_screen.dart
@@ -89,13 +89,13 @@ class _SearchDetailScreenState extends ConsumerState<SearchDetailScreen> {
           spacing: 15,
           children: [
             Text(
-              isFromChallenge ? '새롭게 읽은 책을 찾아보세요' : '책 찾기',
+              isFromChallenge ? '새롭게 읽을 책을 찾아보세요' : '책 찾기',
               style: AppTexts.h4,
             ),
             SearchTextField(
               controller: _textController,
               hintText:
-                  isFromChallenge ? '내가 읽은 책을 검색해 보세요' : '읽고 싶은 책을 검색해 보세요',
+                  isFromChallenge ? '내가 읽을 책을 검색해 보세요' : '읽고 싶은 책을 검색해 보세요',
               hintStyle: AppTexts.b6.copyWith(color: ColorName.g3),
               suffixIcon: _textController.text.isNotEmpty
                   ? Assets.images.icSearchColored3x.image(scale: 3)

--- a/lib/modules/reading_challenge/view/screens/ongoing_challenge_list_screen.dart
+++ b/lib/modules/reading_challenge/view/screens/ongoing_challenge_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:book/common/components/custom_dialog.dart';
+import 'package:book/common/components/text_field/search_text_field.dart';
 import 'package:book/common/theme/app_style.dart';
 import 'package:book/gen/colors.gen.dart';
 import 'package:book/modules/reading_challenge/model/challenge_response.dart';
@@ -8,18 +9,42 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:book/gen/assets.gen.dart';
 
-class OngoingChallengeListScreen extends ConsumerWidget {
+class OngoingChallengeListScreen extends ConsumerStatefulWidget {
   const OngoingChallengeListScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<OngoingChallengeListScreen> createState() => _OngoingChallengeListScreenState();
+}
+
+class _OngoingChallengeListScreenState extends ConsumerState<OngoingChallengeListScreen> {
+  final TextEditingController _textController = TextEditingController();
+  String searchQuery = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _textController.addListener(() {
+      setState(() {
+        searchQuery = _textController.text;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final state = ref.watch(ongoingChallengeViewModelProvider);
     final viewModel = ref.read(ongoingChallengeViewModelProvider.notifier);
     final isSelectionMode = state.isSelectionMode;
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('리딩 챌린지', style: AppTexts.b5),
+        title: Text('리딩 챌린지', style: AppTexts.b5),
         leading: const BackButton(),
       ),
       body: Padding(
@@ -27,12 +52,15 @@ class OngoingChallengeListScreen extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _buildTopSection(viewModel, isSelectionMode),
+            _buildTopSection(viewModel, isSelectionMode, _textController),
             const SizedBox(height: 16),
             Expanded(
               child: state.challenges.when(
-                data: (challenges) =>
-                    _buildChallengeGrid(challenges, state, viewModel),
+                data: (challenges) => _buildChallengeGrid(
+                  challenges.where((challenge) => challenge.book.title.contains(searchQuery)).toList(),
+                  state,
+                  viewModel,
+                ),
                 error: (error, stack) =>
                     const Center(child: Text('챌린지를 불러오는데 실패했습니다.')),
                 loading: () => const Center(child: CircularProgressIndicator()),
@@ -47,11 +75,21 @@ class OngoingChallengeListScreen extends ConsumerWidget {
   }
 
   Widget _buildTopSection(
-      OngoingChallengeViewModel viewModel, bool isSelectionMode) {
+      OngoingChallengeViewModel viewModel, bool isSelectionMode, TextEditingController textController) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Text('완독에 도전 중인 도서를 찾아보세요', style: AppTexts.h4),
+        const SizedBox(height: 8),
+        SearchTextField(
+          controller: textController,
+          hintText:
+              '읽던 책을 검색해 보세요',
+          hintStyle: AppTexts.b6.copyWith(color: ColorName.g3),
+          suffixIcon: textController.text.isNotEmpty
+              ? Assets.images.icSearchColored3x.image(scale: 3)
+              : Assets.images.icSearchUncolored3x.image(scale: 3),
+        ),
         const SizedBox(height: 8),
         Align(
           alignment: Alignment.centerRight,
@@ -151,7 +189,7 @@ class OngoingChallengeListScreen extends ConsumerWidget {
       builder: (_) {
         return CustomDialog(
           title: '챌린지 중단',
-          content: '선택한 ${count}개의 챌린지를 중단하시겠어요?',
+          content: '선택한  ${count}개의 챌린지를 중단하시겠어요?',
           icon: Assets.icons.icReadingChallengeChar1.svg(),
           onCancel: () => Navigator.of(context).pop(),
           onConfirm: () async {

--- a/lib/modules/reading_challenge/view/screens/ongoing_challenge_list_screen.dart
+++ b/lib/modules/reading_challenge/view/screens/ongoing_challenge_list_screen.dart
@@ -189,7 +189,7 @@ class _OngoingChallengeListScreenState extends ConsumerState<OngoingChallengeLis
       builder: (_) {
         return CustomDialog(
           title: '챌린지 중단',
-          content: '선택한  ${count}개의 챌린지를 중단하시겠어요?',
+          content: '선택한 ${count}개의 챌린지를 중단하시겠어요?',
           icon: Assets.icons.icReadingChallengeChar1.svg(),
           onCancel: () => Navigator.of(context).pop(),
           onConfirm: () async {


### PR DESCRIPTION
Fixes #13 

**변경사항**
- 필터링 처리를 위해 `ConsumerStatefulWidget`으로 변경
- 읽던 책 검색 input 추가
- 입력된 `searchQuery`에 따라 `challenges` 필터링
- 텍스트 일부 조정
    - 새롭게 읽"을"
    - 내가 읽"을"





**스크린샷**

| Before | After |
|-------------------|-------------------|
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/167c3fce-d4ac-4b0b-a5e3-35d99548f73f" /> | <video src="https://github.com/user-attachments/assets/133476ea-dbc1-4207-b57b-4b3e3eb08678" /> |



