### PR TITLE
[Fix] #16 "새로운 책 읽기" 선택 후, 뒤로가기시 책픽으로 가는 문제 해결

### DIFF
--- a/lib/modules/reading_challenge/view/screens/reading_challenge_screen.dart
+++ b/lib/modules/reading_challenge/view/screens/reading_challenge_screen.dart
@@ -71,13 +71,15 @@ class ReadingChallengeScreen extends ConsumerWidget {
           text: '시작하기',
           enabled: selectedOption != null,
           onPressed: () {
-            if (selectedOption == ReadingChallengeType.newBook) {
-              context.go(
-                '/book-pick/search?from=challenge',
-              );
-            } else if (selectedOption == ReadingChallengeType.reading) {
+            /** 읽던 책 읽기 */
+            if (selectedOption == ReadingChallengeType.reading) {
               context.go('/reading-challenge/continue-list');
-            } else {
+            } else if (selectedOption == ReadingChallengeType.newBook) {
+            /** 새로운책 읽기*/
+              context.go(
+                '/reading-challenge/search-new?from=challenge',
+              );
+            } else  {
               // TODO: Handle other options
             }
           },


### PR DESCRIPTION
Fixes #16 

**변경사항**
- 원인: router path가`reading-challenge`이 아닌 `book-pick`으로 되어있음
- 대책: `reading-challenge`으로 수정

**스크린샷**

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/ac5a19e1-6d9a-4345-b9d0-dcd70a27430f" /> | <video src="https://github.com/user-attachments/assets/eb810b1e-2156-4a37-955d-c36d1f8bd51b" /> |







