### PR TITLE
[Feat] #19 오늘 읽은 페이지 수 입력시, start에서 end로 바로 이동되도록 하기

### DIFF
--- a/lib/modules/reading_challenge/view/screens/reading_challenge_start_and_end_page_screen.dart
+++ b/lib/modules/reading_challenge/view/screens/reading_challenge_start_and_end_page_screen.dart
@@ -30,6 +30,17 @@ class ReadingChallengeStartAndEndPageScreen extends ConsumerStatefulWidget {
 
 class _ReadingChallengeStartAndEndPageScreenState
     extends ConsumerState<ReadingChallengeStartAndEndPageScreen> {
+
+  final FocusNode startFocusNode = FocusNode();
+  final FocusNode endFocusNode = FocusNode();
+
+  @override
+  void dispose() {
+    startFocusNode.dispose();
+    endFocusNode.dispose();
+    super.dispose();
+  }
+
   @override
   void initState() {
     super.initState();
@@ -108,7 +119,7 @@ class _ReadingChallengeStartAndEndPageScreenState
                         currentStep: 2,
                       ),
                       const SizedBox(height: 40),
-                      _buildPageInputSection(viewModel),
+                      _buildPageInputSection(context, viewModel, startFocusNode, endFocusNode),
                       const SizedBox(height: 24),
                       _buildBottomButtonSection(
                           context, book, widget.totalPages),
@@ -123,7 +134,7 @@ class _ReadingChallengeStartAndEndPageScreenState
     );
   }
 
-  Widget _buildPageInputSection(CurrentChallengeViewModel viewModel) {
+  Widget _buildPageInputSection(BuildContext ctx, CurrentChallengeViewModel viewModel, FocusNode startFocusNode, FocusNode endFocusNode) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -135,12 +146,22 @@ class _ReadingChallengeStartAndEndPageScreenState
         const SizedBox(height: 24),
         _buildPageInputField(
           label: '에서',
+          focusNode: startFocusNode,
+          textInputAction: TextInputAction.next,
           onChanged: (value) => viewModel.setStartPage(value),
+          onSubmitted: () {
+            FocusScope.of(ctx).requestFocus(endFocusNode);
+          },
         ),
         const SizedBox(height: 16),
         _buildPageInputField(
           label: '까지 읽었어요',
+          focusNode: endFocusNode,
+          textInputAction: TextInputAction.done,
           onChanged: (value) => viewModel.setEndPage(value),
+          onSubmitted: () {
+            FocusScope.of(context).unfocus();
+          },
         ),
       ],
     );
@@ -149,15 +170,21 @@ class _ReadingChallengeStartAndEndPageScreenState
   Widget _buildPageInputField({
     required String label,
     required ValueChanged<String> onChanged,
+    FocusNode? focusNode,
+    TextInputAction? textInputAction,
+    Function()? onSubmitted,
   }) {
     return Row(
       children: [
         Expanded(
           child: TextField(
+            focusNode: focusNode,
+            textInputAction: textInputAction,
             onChanged: onChanged,
+            onSubmitted: (_) => onSubmitted,
             textAlign: TextAlign.left,
             style: AppTexts.h3.copyWith(color: ColorName.w1),
-            keyboardType: TextInputType.number,
+            keyboardType: TextInputType.numberWithOptions(signed: true),
             inputFormatters: [FilteringTextInputFormatter.digitsOnly],
             decoration: InputDecoration(
               filled: false,

--- a/lib/modules/reading_challenge/view_model/current_challenge_view_model.dart
+++ b/lib/modules/reading_challenge/view_model/current_challenge_view_model.dart
@@ -136,9 +136,13 @@ class CurrentChallengeViewModel extends _$CurrentChallengeViewModel {
   }
 
   bool get isButtonEnabled {
-    return state.startPage != null &&
-        state.startPage!.isNotEmpty &&
-        state.endPage != null &&
-        state.endPage!.isNotEmpty;
+    bool isValidStartPage = state.startPage != null && state.startPage!.isNotEmpty;
+    bool isValidEndPage = state.endPage != null && state.endPage!.isNotEmpty;
+    int startLength = state.startPage?.length ?? 0;
+    int endLength = state.endPage?.length ?? 0;
+    int start = int.parse(startLength != 0 ? state.startPage! : '0');
+    int end = int.parse(endLength != 0 ? state.endPage! : '0');
+    bool isValidRange = start <= end;
+    return isValidStartPage && isValidEndPage && isValidRange;
   }
 }


### PR DESCRIPTION
Fixes #19 

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. 예: Fixes #123 -->

---

**변경사항**
- 시작 페이지 수 입력시 next 버튼 표시
    - next 버튼 클릭시, 종료 페이지 수 입력으로 이동
- 종료 페이지 수 입력시 done 버튼 표시
- startPage <= endPage일 경우에만 "기록하기" 클릭 가능

<!-- 주요 변경사항을 간단히 설명해주세요. -->

---

**스크린샷**

https://github.com/user-attachments/assets/9901a16c-24b0-43b4-ac47-42d044463aeb


| Before | After |
|--------|-------|
|        |       |

<!-- 변경 전/후 스크린샷을 첨부해주세요. 필요시 이미지를 드래그&드롭 하세요. -->