### PR TITLE
[Feat] #49 채팅 말풍선 유저 클릭시 북로그 표시

### DIFF
--- a/lib/common/router/router.dart
+++ b/lib/common/router/router.dart
@@ -1,5 +1,6 @@
 import 'package:book/modules/book_log/view/screens/feed_screen.dart';
 import 'package:book/modules/book_pick/view/screens/book_pick_result_screen.dart';
+import 'package:book/modules/chat/view/screens/book_talk_chat_room_book_log_screen.dart';
 import 'package:book/modules/chat/view/screens/book_talk_chat_room_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -12,7 +13,6 @@ import '../../modules/auth/view_model/auth_view_model.dart';
 import '../../modules/book/view/screens/book_overview_screen.dart';
 import '../../modules/book_log/view/screens/book_log_diary_screen.dart';
 import '../../modules/book_log/view/screens/book_log_screen.dart';
-import '../../modules/book_log/view/screens/feed_screen.dart';
 import '../../modules/book_pick/model/search_book_response.dart';
 import '../../modules/book_pick/view/screens/book_pick_screen.dart';
 import '../../modules/book_pick/view/screens/book_pick_search_screen.dart';
@@ -194,13 +194,25 @@ GoRouter router(Ref ref) {
                 builder: (context, state) => const BookTalkScreen(),
                 routes: [
                   GoRoute(
-                    path: 'chat-room/:roomId',
-                    parentNavigatorKey: rootNavigatorKey,
-                    builder: (context, state) {
-                      final roomId = int.parse(state.pathParameters['roomId']!);
-                      return BookTalkChatRoomScreen(roomId: roomId);
-                    },
-                  ),
+                      path: 'chat-room/:roomId',
+                      parentNavigatorKey: rootNavigatorKey,
+                      builder: (context, state) {
+                        final roomId =
+                            int.parse(state.pathParameters['roomId']!);
+                        return BookTalkChatRoomScreen(roomId: roomId);
+                      },
+                      routes: [
+                        GoRoute(
+                          path: 'book-log/:memberId',
+                          parentNavigatorKey: rootNavigatorKey,
+                          builder: (context, state) {
+                            final memberId =
+                                int.parse(state.pathParameters['memberId']!);
+                            return BookTalkChatRoomBookLogScreen(
+                                memberId: memberId);
+                          },
+                        ),
+                      ]),
                 ],
               ),
             ],

--- a/lib/modules/book_log/view/screens/book_log_screen.dart
+++ b/lib/modules/book_log/view/screens/book_log_screen.dart
@@ -13,14 +13,15 @@ import '../widgets/book_log_mid_section.dart';
 import 'package:book/modules/reading_challenge/view_model/get_challenges_by_member_view_model.dart';
 
 class BookLogScreen extends ConsumerWidget {
-  const BookLogScreen({super.key, this.showAppBar = true});
+  const BookLogScreen({super.key, this.showAppBar = true, this.otherMemberId = 0});
   final bool showAppBar;
+  final int otherMemberId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final user = ref.watch(authViewModelProvider).value;
-    final memberId = (user is AuthSuccess) ? user.memberId : 0;
-    final isMyProfile = user is AuthSuccess && user.memberId == memberId;
+    final memberId = otherMemberId == 0 ? ((user is AuthSuccess) ? user.memberId : 0) : otherMemberId;
+    final isMyProfile = otherMemberId == 0 ? (user is AuthSuccess && user.memberId == memberId) : false;
 
     final profileAsync = ref.watch(bookLogProfileProvider(memberId));
     final challengesAsync = ref

--- a/lib/modules/book_pick/view/widgets/book_search_result_card.dart
+++ b/lib/modules/book_pick/view/widgets/book_search_result_card.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../../common/components/dialog/custom_dialog.dart';
 import '../../../../common/utils/overlay_utils.dart';
 import '../../model/search_book_response.dart';
 import 'book_cover_image.dart';

--- a/lib/modules/chat/view/screens/book_talk_chat_room_book_log_screen.dart
+++ b/lib/modules/chat/view/screens/book_talk_chat_room_book_log_screen.dart
@@ -3,25 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class BookTalkChatRoomBookLogScreen extends ConsumerStatefulWidget {
+class BookTalkChatRoomBookLogScreen extends ConsumerWidget {
   const BookTalkChatRoomBookLogScreen({super.key, required this.memberId});
 
   final int memberId;
 
   @override
-  ConsumerState<BookTalkChatRoomBookLogScreen> createState() =>
-      _BookTalkChatRoomBookLogScreen();
-}
-
-class _BookTalkChatRoomBookLogScreen
-    extends ConsumerState<BookTalkChatRoomBookLogScreen> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
         actions: [
@@ -32,7 +20,7 @@ class _BookTalkChatRoomBookLogScreen
         ],
       ),
       body: BookLogScreen(
-        otherMemberId: widget.memberId,
+        otherMemberId: memberId,
       ),
     );
   }

--- a/lib/modules/chat/view/screens/book_talk_chat_room_book_log_screen.dart
+++ b/lib/modules/chat/view/screens/book_talk_chat_room_book_log_screen.dart
@@ -1,0 +1,39 @@
+import 'package:book/modules/book_log/view/screens/book_log_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class BookTalkChatRoomBookLogScreen extends ConsumerStatefulWidget {
+  const BookTalkChatRoomBookLogScreen({super.key, required this.memberId});
+
+  final int memberId;
+
+  @override
+  ConsumerState<BookTalkChatRoomBookLogScreen> createState() =>
+      _BookTalkChatRoomBookLogScreen();
+}
+
+class _BookTalkChatRoomBookLogScreen
+    extends ConsumerState<BookTalkChatRoomBookLogScreen> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => context.pop(),
+          ),
+        ],
+      ),
+      body: BookLogScreen(
+        otherMemberId: widget.memberId,
+      ),
+    );
+  }
+}

--- a/lib/modules/chat/view/screens/book_talk_chat_room_screen.dart
+++ b/lib/modules/chat/view/screens/book_talk_chat_room_screen.dart
@@ -148,17 +148,23 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
       ScrollController scrollController, ChatState data, int currentMemberId) {
     final messages = data.chatHistory.data;
 
-    ClipRRect? getProfileImage(int senderId) {
+    Widget? getProfileImage(int senderId) {
       final profileImageUrl = data.chatParticipants.participants
           .firstWhereOrNull((participant) => participant.memberId == senderId)
           ?.profileImageUrl;
       return profileImageUrl != null
-          ? ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: CachedNetworkImage(
-                imageUrl: profileImageUrl,
-                width: 40,
-                height: 40,
+          ? GestureDetector(
+              onTap: () {
+                context.push(
+                    '/book-talk/chat-room/${widget.roomId}/book-log/$senderId');
+              },
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: CachedNetworkImage(
+                  imageUrl: profileImageUrl,
+                  width: 40,
+                  height: 40,
+                ),
               ),
             )
           : null;


### PR DESCRIPTION
Fixes #49

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. 예: Fixes #123 -->

---

**변경사항**
- 북로그 위젯, 책톡용으로 래핑(`book_talk_chat_room_book_log_screen.dart`)
- 북로그 위젯, 다이어로그 용으로 사용할 수 있게 수정


<!-- 주요 변경사항을 간단히 설명해주세요. -->

---

**스크린샷**


https://github.com/user-attachments/assets/84f19ee4-44c4-4e6d-bfac-0f8b8347b97b



| Before | After |
|--------|-------|
|        |       |

<!-- 변경 전/후 스크린샷을 첨부해주세요. 필요시 이미지를 드래그&드롭 하세요. -->