### PR TITLE
[Feat] #53 ably 적용, 스크롤로 과거 채팅 취득

### DIFF
--- a/lib/modules/chat/state/chat_state.dart
+++ b/lib/modules/chat/state/chat_state.dart
@@ -11,7 +11,7 @@ abstract class ChatState with _$ChatState {
     @Default([]) List<ChatRoomResponse> myChatRooms,
     @Default([]) List<ChatMessageResponse> chatHistory,
     @Default(false) bool hasNext,
-    int? nextCursor,
+    @Default(-1) int nextCursor,
     @Default(
       ChatParticipantResponse()
     ) ChatParticipantResponse chatParticipants,

--- a/lib/modules/chat/state/chat_state.dart
+++ b/lib/modules/chat/state/chat_state.dart
@@ -1,4 +1,3 @@
-import 'package:book/common/models/cursor_page_response.dart';
 import 'package:book/modules/chat/model/chat_message_response.dart';
 import 'package:book/modules/chat/model/chat_participant_response.dart';
 import 'package:book/modules/chat/model/chat_room_response.dart';
@@ -10,12 +9,9 @@ part 'chat_state.freezed.dart';
 abstract class ChatState with _$ChatState {
   const factory ChatState({
     @Default([]) List<ChatRoomResponse> myChatRooms,
-    @Default(
-      CursorPageResponse(
-        data: [],
-        hasNext: false,
-      )
-    ) CursorPageResponse<ChatMessageResponse> chatHistory,
+    @Default([]) List<ChatMessageResponse> chatHistory,
+    @Default(false) bool hasNext,
+    int? nextCursor,
     @Default(
       ChatParticipantResponse()
     ) ChatParticipantResponse chatParticipants,

--- a/lib/modules/chat/state/chat_state.freezed.dart
+++ b/lib/modules/chat/state/chat_state.freezed.dart
@@ -17,7 +17,7 @@ mixin _$ChatState {
   List<ChatRoomResponse> get myChatRooms;
   List<ChatMessageResponse> get chatHistory;
   bool get hasNext;
-  int? get nextCursor;
+  int get nextCursor;
   ChatParticipantResponse get chatParticipants;
 
   /// Create a copy of ChatState
@@ -67,7 +67,7 @@ abstract mixin class $ChatStateCopyWith<$Res> {
       {List<ChatRoomResponse> myChatRooms,
       List<ChatMessageResponse> chatHistory,
       bool hasNext,
-      int? nextCursor,
+      int nextCursor,
       ChatParticipantResponse chatParticipants});
 
   $ChatParticipantResponseCopyWith<$Res> get chatParticipants;
@@ -88,7 +88,7 @@ class _$ChatStateCopyWithImpl<$Res> implements $ChatStateCopyWith<$Res> {
     Object? myChatRooms = null,
     Object? chatHistory = null,
     Object? hasNext = null,
-    Object? nextCursor = freezed,
+    Object? nextCursor = null,
     Object? chatParticipants = null,
   }) {
     return _then(_self.copyWith(
@@ -104,10 +104,10 @@ class _$ChatStateCopyWithImpl<$Res> implements $ChatStateCopyWith<$Res> {
           ? _self.hasNext
           : hasNext // ignore: cast_nullable_to_non_nullable
               as bool,
-      nextCursor: freezed == nextCursor
+      nextCursor: null == nextCursor
           ? _self.nextCursor
           : nextCursor // ignore: cast_nullable_to_non_nullable
-              as int?,
+              as int,
       chatParticipants: null == chatParticipants
           ? _self.chatParticipants
           : chatParticipants // ignore: cast_nullable_to_non_nullable
@@ -224,7 +224,7 @@ extension ChatStatePatterns on ChatState {
             List<ChatRoomResponse> myChatRooms,
             List<ChatMessageResponse> chatHistory,
             bool hasNext,
-            int? nextCursor,
+            int nextCursor,
             ChatParticipantResponse chatParticipants)?
         $default, {
     required TResult orElse(),
@@ -258,7 +258,7 @@ extension ChatStatePatterns on ChatState {
             List<ChatRoomResponse> myChatRooms,
             List<ChatMessageResponse> chatHistory,
             bool hasNext,
-            int? nextCursor,
+            int nextCursor,
             ChatParticipantResponse chatParticipants)
         $default,
   ) {
@@ -290,7 +290,7 @@ extension ChatStatePatterns on ChatState {
             List<ChatRoomResponse> myChatRooms,
             List<ChatMessageResponse> chatHistory,
             bool hasNext,
-            int? nextCursor,
+            int nextCursor,
             ChatParticipantResponse chatParticipants)?
         $default,
   ) {
@@ -312,7 +312,7 @@ class _ChatState implements ChatState {
       {final List<ChatRoomResponse> myChatRooms = const [],
       final List<ChatMessageResponse> chatHistory = const [],
       this.hasNext = false,
-      this.nextCursor,
+      this.nextCursor = -1,
       this.chatParticipants = const ChatParticipantResponse()})
       : _myChatRooms = myChatRooms,
         _chatHistory = chatHistory;
@@ -339,7 +339,8 @@ class _ChatState implements ChatState {
   @JsonKey()
   final bool hasNext;
   @override
-  final int? nextCursor;
+  @JsonKey()
+  final int nextCursor;
   @override
   @JsonKey()
   final ChatParticipantResponse chatParticipants;
@@ -395,7 +396,7 @@ abstract mixin class _$ChatStateCopyWith<$Res>
       {List<ChatRoomResponse> myChatRooms,
       List<ChatMessageResponse> chatHistory,
       bool hasNext,
-      int? nextCursor,
+      int nextCursor,
       ChatParticipantResponse chatParticipants});
 
   @override
@@ -417,7 +418,7 @@ class __$ChatStateCopyWithImpl<$Res> implements _$ChatStateCopyWith<$Res> {
     Object? myChatRooms = null,
     Object? chatHistory = null,
     Object? hasNext = null,
-    Object? nextCursor = freezed,
+    Object? nextCursor = null,
     Object? chatParticipants = null,
   }) {
     return _then(_ChatState(
@@ -433,10 +434,10 @@ class __$ChatStateCopyWithImpl<$Res> implements _$ChatStateCopyWith<$Res> {
           ? _self.hasNext
           : hasNext // ignore: cast_nullable_to_non_nullable
               as bool,
-      nextCursor: freezed == nextCursor
+      nextCursor: null == nextCursor
           ? _self.nextCursor
           : nextCursor // ignore: cast_nullable_to_non_nullable
-              as int?,
+              as int,
       chatParticipants: null == chatParticipants
           ? _self.chatParticipants
           : chatParticipants // ignore: cast_nullable_to_non_nullable

--- a/lib/modules/chat/state/chat_state.freezed.dart
+++ b/lib/modules/chat/state/chat_state.freezed.dart
@@ -15,7 +15,9 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ChatState {
   List<ChatRoomResponse> get myChatRooms;
-  CursorPageResponse<ChatMessageResponse> get chatHistory;
+  List<ChatMessageResponse> get chatHistory;
+  bool get hasNext;
+  int? get nextCursor;
   ChatParticipantResponse get chatParticipants;
 
   /// Create a copy of ChatState
@@ -32,8 +34,11 @@ mixin _$ChatState {
             other is ChatState &&
             const DeepCollectionEquality()
                 .equals(other.myChatRooms, myChatRooms) &&
-            (identical(other.chatHistory, chatHistory) ||
-                other.chatHistory == chatHistory) &&
+            const DeepCollectionEquality()
+                .equals(other.chatHistory, chatHistory) &&
+            (identical(other.hasNext, hasNext) || other.hasNext == hasNext) &&
+            (identical(other.nextCursor, nextCursor) ||
+                other.nextCursor == nextCursor) &&
             (identical(other.chatParticipants, chatParticipants) ||
                 other.chatParticipants == chatParticipants));
   }
@@ -42,12 +47,14 @@ mixin _$ChatState {
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(myChatRooms),
-      chatHistory,
+      const DeepCollectionEquality().hash(chatHistory),
+      hasNext,
+      nextCursor,
       chatParticipants);
 
   @override
   String toString() {
-    return 'ChatState(myChatRooms: $myChatRooms, chatHistory: $chatHistory, chatParticipants: $chatParticipants)';
+    return 'ChatState(myChatRooms: $myChatRooms, chatHistory: $chatHistory, hasNext: $hasNext, nextCursor: $nextCursor, chatParticipants: $chatParticipants)';
   }
 }
 
@@ -58,10 +65,11 @@ abstract mixin class $ChatStateCopyWith<$Res> {
   @useResult
   $Res call(
       {List<ChatRoomResponse> myChatRooms,
-      CursorPageResponse<ChatMessageResponse> chatHistory,
+      List<ChatMessageResponse> chatHistory,
+      bool hasNext,
+      int? nextCursor,
       ChatParticipantResponse chatParticipants});
 
-  $CursorPageResponseCopyWith<ChatMessageResponse, $Res> get chatHistory;
   $ChatParticipantResponseCopyWith<$Res> get chatParticipants;
 }
 
@@ -79,6 +87,8 @@ class _$ChatStateCopyWithImpl<$Res> implements $ChatStateCopyWith<$Res> {
   $Res call({
     Object? myChatRooms = null,
     Object? chatHistory = null,
+    Object? hasNext = null,
+    Object? nextCursor = freezed,
     Object? chatParticipants = null,
   }) {
     return _then(_self.copyWith(
@@ -89,23 +99,20 @@ class _$ChatStateCopyWithImpl<$Res> implements $ChatStateCopyWith<$Res> {
       chatHistory: null == chatHistory
           ? _self.chatHistory
           : chatHistory // ignore: cast_nullable_to_non_nullable
-              as CursorPageResponse<ChatMessageResponse>,
+              as List<ChatMessageResponse>,
+      hasNext: null == hasNext
+          ? _self.hasNext
+          : hasNext // ignore: cast_nullable_to_non_nullable
+              as bool,
+      nextCursor: freezed == nextCursor
+          ? _self.nextCursor
+          : nextCursor // ignore: cast_nullable_to_non_nullable
+              as int?,
       chatParticipants: null == chatParticipants
           ? _self.chatParticipants
           : chatParticipants // ignore: cast_nullable_to_non_nullable
               as ChatParticipantResponse,
     ));
-  }
-
-  /// Create a copy of ChatState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $CursorPageResponseCopyWith<ChatMessageResponse, $Res> get chatHistory {
-    return $CursorPageResponseCopyWith<ChatMessageResponse, $Res>(
-        _self.chatHistory, (value) {
-      return _then(_self.copyWith(chatHistory: value));
-    });
   }
 
   /// Create a copy of ChatState
@@ -215,7 +222,9 @@ extension ChatStatePatterns on ChatState {
   TResult maybeWhen<TResult extends Object?>(
     TResult Function(
             List<ChatRoomResponse> myChatRooms,
-            CursorPageResponse<ChatMessageResponse> chatHistory,
+            List<ChatMessageResponse> chatHistory,
+            bool hasNext,
+            int? nextCursor,
             ChatParticipantResponse chatParticipants)?
         $default, {
     required TResult orElse(),
@@ -223,8 +232,8 @@ extension ChatStatePatterns on ChatState {
     final _that = this;
     switch (_that) {
       case _ChatState() when $default != null:
-        return $default(
-            _that.myChatRooms, _that.chatHistory, _that.chatParticipants);
+        return $default(_that.myChatRooms, _that.chatHistory, _that.hasNext,
+            _that.nextCursor, _that.chatParticipants);
       case _:
         return orElse();
     }
@@ -247,15 +256,17 @@ extension ChatStatePatterns on ChatState {
   TResult when<TResult extends Object?>(
     TResult Function(
             List<ChatRoomResponse> myChatRooms,
-            CursorPageResponse<ChatMessageResponse> chatHistory,
+            List<ChatMessageResponse> chatHistory,
+            bool hasNext,
+            int? nextCursor,
             ChatParticipantResponse chatParticipants)
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _ChatState():
-        return $default(
-            _that.myChatRooms, _that.chatHistory, _that.chatParticipants);
+        return $default(_that.myChatRooms, _that.chatHistory, _that.hasNext,
+            _that.nextCursor, _that.chatParticipants);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -277,15 +288,17 @@ extension ChatStatePatterns on ChatState {
   TResult? whenOrNull<TResult extends Object?>(
     TResult? Function(
             List<ChatRoomResponse> myChatRooms,
-            CursorPageResponse<ChatMessageResponse> chatHistory,
+            List<ChatMessageResponse> chatHistory,
+            bool hasNext,
+            int? nextCursor,
             ChatParticipantResponse chatParticipants)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _ChatState() when $default != null:
-        return $default(
-            _that.myChatRooms, _that.chatHistory, _that.chatParticipants);
+        return $default(_that.myChatRooms, _that.chatHistory, _that.hasNext,
+            _that.nextCursor, _that.chatParticipants);
       case _:
         return null;
     }
@@ -297,9 +310,12 @@ extension ChatStatePatterns on ChatState {
 class _ChatState implements ChatState {
   const _ChatState(
       {final List<ChatRoomResponse> myChatRooms = const [],
-      this.chatHistory = const CursorPageResponse(data: [], hasNext: false),
+      final List<ChatMessageResponse> chatHistory = const [],
+      this.hasNext = false,
+      this.nextCursor,
       this.chatParticipants = const ChatParticipantResponse()})
-      : _myChatRooms = myChatRooms;
+      : _myChatRooms = myChatRooms,
+        _chatHistory = chatHistory;
 
   final List<ChatRoomResponse> _myChatRooms;
   @override
@@ -310,9 +326,20 @@ class _ChatState implements ChatState {
     return EqualUnmodifiableListView(_myChatRooms);
   }
 
+  final List<ChatMessageResponse> _chatHistory;
   @override
   @JsonKey()
-  final CursorPageResponse<ChatMessageResponse> chatHistory;
+  List<ChatMessageResponse> get chatHistory {
+    if (_chatHistory is EqualUnmodifiableListView) return _chatHistory;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_chatHistory);
+  }
+
+  @override
+  @JsonKey()
+  final bool hasNext;
+  @override
+  final int? nextCursor;
   @override
   @JsonKey()
   final ChatParticipantResponse chatParticipants;
@@ -332,8 +359,11 @@ class _ChatState implements ChatState {
             other is _ChatState &&
             const DeepCollectionEquality()
                 .equals(other._myChatRooms, _myChatRooms) &&
-            (identical(other.chatHistory, chatHistory) ||
-                other.chatHistory == chatHistory) &&
+            const DeepCollectionEquality()
+                .equals(other._chatHistory, _chatHistory) &&
+            (identical(other.hasNext, hasNext) || other.hasNext == hasNext) &&
+            (identical(other.nextCursor, nextCursor) ||
+                other.nextCursor == nextCursor) &&
             (identical(other.chatParticipants, chatParticipants) ||
                 other.chatParticipants == chatParticipants));
   }
@@ -342,12 +372,14 @@ class _ChatState implements ChatState {
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_myChatRooms),
-      chatHistory,
+      const DeepCollectionEquality().hash(_chatHistory),
+      hasNext,
+      nextCursor,
       chatParticipants);
 
   @override
   String toString() {
-    return 'ChatState(myChatRooms: $myChatRooms, chatHistory: $chatHistory, chatParticipants: $chatParticipants)';
+    return 'ChatState(myChatRooms: $myChatRooms, chatHistory: $chatHistory, hasNext: $hasNext, nextCursor: $nextCursor, chatParticipants: $chatParticipants)';
   }
 }
 
@@ -361,11 +393,11 @@ abstract mixin class _$ChatStateCopyWith<$Res>
   @useResult
   $Res call(
       {List<ChatRoomResponse> myChatRooms,
-      CursorPageResponse<ChatMessageResponse> chatHistory,
+      List<ChatMessageResponse> chatHistory,
+      bool hasNext,
+      int? nextCursor,
       ChatParticipantResponse chatParticipants});
 
-  @override
-  $CursorPageResponseCopyWith<ChatMessageResponse, $Res> get chatHistory;
   @override
   $ChatParticipantResponseCopyWith<$Res> get chatParticipants;
 }
@@ -384,6 +416,8 @@ class __$ChatStateCopyWithImpl<$Res> implements _$ChatStateCopyWith<$Res> {
   $Res call({
     Object? myChatRooms = null,
     Object? chatHistory = null,
+    Object? hasNext = null,
+    Object? nextCursor = freezed,
     Object? chatParticipants = null,
   }) {
     return _then(_ChatState(
@@ -392,25 +426,22 @@ class __$ChatStateCopyWithImpl<$Res> implements _$ChatStateCopyWith<$Res> {
           : myChatRooms // ignore: cast_nullable_to_non_nullable
               as List<ChatRoomResponse>,
       chatHistory: null == chatHistory
-          ? _self.chatHistory
+          ? _self._chatHistory
           : chatHistory // ignore: cast_nullable_to_non_nullable
-              as CursorPageResponse<ChatMessageResponse>,
+              as List<ChatMessageResponse>,
+      hasNext: null == hasNext
+          ? _self.hasNext
+          : hasNext // ignore: cast_nullable_to_non_nullable
+              as bool,
+      nextCursor: freezed == nextCursor
+          ? _self.nextCursor
+          : nextCursor // ignore: cast_nullable_to_non_nullable
+              as int?,
       chatParticipants: null == chatParticipants
           ? _self.chatParticipants
           : chatParticipants // ignore: cast_nullable_to_non_nullable
               as ChatParticipantResponse,
     ));
-  }
-
-  /// Create a copy of ChatState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $CursorPageResponseCopyWith<ChatMessageResponse, $Res> get chatHistory {
-    return $CursorPageResponseCopyWith<ChatMessageResponse, $Res>(
-        _self.chatHistory, (value) {
-      return _then(_self.copyWith(chatHistory: value));
-    });
   }
 
   /// Create a copy of ChatState

--- a/lib/modules/chat/view/screens/book_talk_chat_room_screen.dart
+++ b/lib/modules/chat/view/screens/book_talk_chat_room_screen.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart';
 
 class BookTalkChatRoomScreen extends ConsumerStatefulWidget {
   const BookTalkChatRoomScreen({super.key, required this.roomId});
@@ -38,6 +39,7 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
   void initState() {
     super.initState();
     _scrollController = ScrollController();
+    _scrollController.addListener(_onScroll);
     _textController.addListener(() {
       setState(() {});
     });
@@ -50,6 +52,17 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
           .initAbly(widget.roomId);
       _subscribe();
     });
+  }
+
+  void _onScroll() async {
+    const margin = 10;
+    // 맨 위에 도달했는지 확인
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent + margin) {
+      await ref
+          .read(chatViewModelProvider.notifier)
+          .fetchPreviousChatHistory(widget.roomId);
+    }
   }
 
   _subscribe() {
@@ -210,6 +223,13 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
       }
     }
 
+    Widget getDateWidget(String createdAt) {
+      DateTime dt = DateTime.parse(createdAt);
+
+      String formatted = DateFormat('MM/dd\nHH:mm').format(dt);
+      return Text(formatted, style: AppTexts.b12.copyWith(color: ColorName.w1));
+    }
+
     return messages.isEmpty
         ? _buildEmptyChatRoom()
         : Padding(
@@ -250,8 +270,12 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
                                     child: getChatWidget(message, textStyle),
                                   ),
                                 ),
+                                SizedBox(width: 6,),
+                                getDateWidget(message.createdAt),
                               ]
                             : [
+                                getDateWidget(message.createdAt),
+                                SizedBox(width: 6,),
                                 ConstrainedBox(
                                   constraints: BoxConstraints(maxWidth: 140),
                                   child: Container(

--- a/lib/modules/chat/view/screens/book_talk_chat_room_screen.dart
+++ b/lib/modules/chat/view/screens/book_talk_chat_room_screen.dart
@@ -170,7 +170,7 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
 
   Widget _buildChatHistory(
       ScrollController scrollController, ChatState data, int currentMemberId) {
-    final messages = data.chatHistory.data;
+    final messages = data.chatHistory;
 
     Widget? getProfileImage(int senderId) {
       final profileImageUrl = data.chatParticipants.participants

--- a/lib/modules/chat/view_model/chat_view_model.dart
+++ b/lib/modules/chat/view_model/chat_view_model.dart
@@ -122,22 +122,21 @@ class ChatViewModel extends _$ChatViewModel {
     state = AsyncValue.data(prev.copyWith(
         chatHistory: chatHistory.data, 
         hasNext: chatHistory.hasNext,
-        nextCursor: chatHistory.nextCursor,
+        nextCursor: chatHistory.nextCursor ?? -1,
         chatParticipants: chatParticipants));
   }
 
     /// 채팅방 참여 직후, 필요 데이터 취득
   Future<void> fetchPreviousChatHistory(int roomId) async {
     final prev = state.value ?? ChatState();
-    if(!prev.hasNext || prev.nextCursor == null) return;
+    if(!prev.hasNext || prev.nextCursor == -1) return;
     // state = AsyncValue.loading();
-    final newChatHistory = await getChatHistory(roomId, cursorId: prev.nextCursor);
-    final sortedNewChatHistory = _sortChatHistory([...newChatHistory.data, ...prev.chatHistory]);
+    final previousChatHistory = await getChatHistory(roomId, cursorId: prev.nextCursor);
     state = AsyncValue.data(
       prev.copyWith(
-        hasNext: newChatHistory.hasNext,
-        nextCursor: newChatHistory.nextCursor,
-        chatHistory: sortedNewChatHistory,
+        hasNext: previousChatHistory.hasNext,
+        nextCursor: previousChatHistory.nextCursor ?? -1,
+        chatHistory: [...previousChatHistory.data, ...prev.chatHistory,  ],
       ),
     );
   }

--- a/lib/modules/chat/view_model/chat_view_model.dart
+++ b/lib/modules/chat/view_model/chat_view_model.dart
@@ -120,23 +120,27 @@ class ChatViewModel extends _$ChatViewModel {
     final chatHistory = await getChatHistory(roomId);
     final chatParticipants = await getChatParticipants(roomId);
     state = AsyncValue.data(prev.copyWith(
-        chatHistory: chatHistory.data, 
+        chatHistory: chatHistory.data,
         hasNext: chatHistory.hasNext,
         nextCursor: chatHistory.nextCursor ?? -1,
         chatParticipants: chatParticipants));
   }
 
-    /// 채팅방 참여 직후, 필요 데이터 취득
+  /// scroll top, 이전 채팅 내역 취득
   Future<void> fetchPreviousChatHistory(int roomId) async {
     final prev = state.value ?? ChatState();
-    if(!prev.hasNext || prev.nextCursor == -1) return;
+    if (!prev.hasNext || prev.nextCursor == -1) return;
     // state = AsyncValue.loading();
-    final previousChatHistory = await getChatHistory(roomId, cursorId: prev.nextCursor);
+    final previousChatHistory =
+        await getChatHistory(roomId, cursorId: prev.nextCursor);
     state = AsyncValue.data(
       prev.copyWith(
         hasNext: previousChatHistory.hasNext,
         nextCursor: previousChatHistory.nextCursor ?? -1,
-        chatHistory: [...previousChatHistory.data, ...prev.chatHistory,  ],
+        chatHistory: [
+          ...prev.chatHistory,
+          ...previousChatHistory.data,
+        ],
       ),
     );
   }
@@ -168,10 +172,9 @@ class ChatViewModel extends _$ChatViewModel {
       final response = ChatMessageResponse.fromJson(map);
       final prev = state.value ?? ChatState();
       // 기존 상태에서 chatHistory.data에 아이템 하나 추가
-      final sortedNewChatHistory = _sortChatHistory([...prev.chatHistory, response]);
       state = AsyncValue.data(
         prev.copyWith(
-          chatHistory: sortedNewChatHistory,
+          chatHistory: [response, ...prev.chatHistory, ],
         ),
       );
     }

--- a/lib/modules/chat/view_model/chat_view_model.dart
+++ b/lib/modules/chat/view_model/chat_view_model.dart
@@ -123,6 +123,23 @@ class ChatViewModel extends _$ChatViewModel {
         chatHistory: chatHistory, chatParticipants: chatParticipants));
   }
 
+    /// 채팅방 참여 직후, 필요 데이터 취득
+  Future<void> fetchPreviousChatHistory(int roomId) async {
+    final prev = state.value ?? ChatState();
+    if(!prev.chatHistory.hasNext || prev.chatHistory.nextCursor == null) return;
+    state = AsyncValue.loading();
+    final newChatHistory = await getChatHistory(roomId, cursorId: prev.chatHistory.nextCursor);
+    state = AsyncValue.data(
+      prev.copyWith(
+        chatHistory: prev.chatHistory.copyWith(
+          hasNext: newChatHistory.hasNext,
+          nextCursor: newChatHistory.nextCursor,
+          data: _sortChatHistory([...newChatHistory.data, ...prev.chatHistory.data]),
+        ),
+      ),
+    );
+  }
+
   Future<ably.RealtimeChannel> initAbly(int roomId) async {
     final response = await _repository.getAblyToken();
     final token = response.data.token;

--- a/lib/modules/chat/view_model/chat_view_model.g.dart
+++ b/lib/modules/chat/view_model/chat_view_model.g.dart
@@ -6,7 +6,7 @@ part of 'chat_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatViewModelHash() => r'975bdc991119327f3266df601a6454bbfc81cab8';
+String _$chatViewModelHash() => r'406078cb53a79fc9cd527c80184eae3f341071a6';
 
 /// See also [ChatViewModel].
 @ProviderFor(ChatViewModel)

--- a/lib/modules/chat/view_model/chat_view_model.g.dart
+++ b/lib/modules/chat/view_model/chat_view_model.g.dart
@@ -6,7 +6,7 @@ part of 'chat_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatViewModelHash() => r'406078cb53a79fc9cd527c80184eae3f341071a6';
+String _$chatViewModelHash() => r'd84e963bb15f62a274b80db9d6cdea74fe7e10cc';
 
 /// See also [ChatViewModel].
 @ProviderFor(ChatViewModel)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.58"
+  ably_flutter:
+    dependency: "direct main"
+    description:
+      name: ably_flutter
+      sha256: f79aa013d96e3dc1f2974a118f4178f17b4ff2621f1fbe08f0a761968e0080f9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.40"
   analyzer:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -800,6 +800,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   flutter_rating_bar: ^4.0.1
   collection: ^1.19.1
   ably_flutter: ^1.2.40
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   sleek_circular_slider: ^2.0.1
   flutter_rating_bar: ^4.0.1
   collection: ^1.19.1
+  ably_flutter: ^1.2.40
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes #53

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. 예: Fixes #123 -->

---

**변경사항**
- FE에서 ably subscribe, publish 모두 수행
    - 채팅방 진입직후와 API를 통해 최신 채팅 가져옴
    - 그 후 새로 추가된 채팅은 ably subscribe를 통해 추가 됨
    - 채팅을 전송한 경우, API response를 ably publish(이를 subscribe listen에서 최신 채팅 아이템 추가)
- 스크롤하면 이전 히스토리 취득 및적용
- ChatViewModel 정리
- 스크롤 테스트를 위해 createdAt 텍스트 추가
- [x] 채팅 내역 취득 API 설계 및 정상 취득 확인 필요

<!-- 주요 변경사항을 간단히 설명해주세요. -->

---

**스크린샷**


https://github.com/user-attachments/assets/88fc8218-1900-412f-a609-93b3a64a5dc7




| Before | After |
|--------|-------|
|        |       |

<!-- 변경 전/후 스크린샷을 첨부해주세요. 필요시 이미지를 드래그&드롭 하세요. -->