### PR TITLE
[Feat] #56 책톡:채팅 키보드 제어 [Feat] #57 리딩챌린지:완독 도서 화면, 도서 클릭시 도서 상세로 이동 

### DIFF
--- a/lib/common/components/text_field/search_text_field.dart
+++ b/lib/common/components/text_field/search_text_field.dart
@@ -21,6 +21,7 @@ class SearchTextField extends StatelessWidget {
   final VoidCallback? onTap;
   final TextInputType? keyboardType; 
   final int? maxLines; 
+  final FocusNode? focusNode;
 
   const SearchTextField({
     super.key,
@@ -40,6 +41,7 @@ class SearchTextField extends StatelessWidget {
     this.onTap,
     this.keyboardType,
     this.maxLines = 1,
+    this.focusNode,
   });
 
   @override
@@ -54,6 +56,7 @@ class SearchTextField extends StatelessWidget {
     return SizedBox(
       height: height,
       child: TextField(
+        focusNode: focusNode,
         controller: controller,
         onTap: onTap,
         style: TextStyle(

--- a/lib/modules/chat/view/screens/book_talk_chat_room_screen.dart
+++ b/lib/modules/chat/view/screens/book_talk_chat_room_screen.dart
@@ -34,7 +34,7 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
   bool _visibleOption = false;
   final ImagePicker _picker = ImagePicker();
   ably.RealtimeChannel? _channel;
-  final FocusNode chatInputFocusNode = FocusNode();
+  final FocusNode _chatInputFocusNode = FocusNode();
 
   @override
   void initState() {
@@ -82,7 +82,7 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
     setState(() {
       _visibleOption = value;
     });
-    if (value) chatInputFocusNode.unfocus();
+    if (value) _chatInputFocusNode.unfocus();
   }
 
   _handleTextSend() async {
@@ -127,7 +127,7 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
   }
 
   _clearChatInput() {
-    chatInputFocusNode.unfocus();
+    _chatInputFocusNode.unfocus();
     _updateVisibleOption(false);
   }
 
@@ -171,7 +171,7 @@ class _BookTalkChatRoomScreen extends ConsumerState<BookTalkChatRoomScreen> {
                 ChatInputWrap(
                   textController: _textController,
                   visibleOption: _visibleOption,
-                  focusNode: chatInputFocusNode,
+                  focusNode: _chatInputFocusNode,
                   updateVisibleOption: _updateVisibleOption,
                   handleTextSend: _handleTextSend,
                   clickInputOption: _clickInputOption,

--- a/lib/modules/chat/view/widgets/chat_input_wrap.dart
+++ b/lib/modules/chat/view/widgets/chat_input_wrap.dart
@@ -1,8 +1,8 @@
-import 'package:book/common/components/text_field/search_text_field.dart';
 import 'package:book/common/theme/style/app_paddings.dart';
 import 'package:book/common/theme/style/app_texts.dart';
 import 'package:book/gen/assets.gen.dart';
 import 'package:book/gen/colors.gen.dart';
+import 'package:book/modules/chat/view/widgets/chat_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
@@ -78,7 +78,7 @@ class ChatInputWrap extends ConsumerWidget {
           width: 24,
         ),
         Expanded(
-          child: SearchTextField(
+          child: ChatTextField(
             focusNode: focusNode,
             controller: textController,
             backgroundColor: ColorName.w1,
@@ -100,7 +100,7 @@ class ChatInputWrap extends ConsumerWidget {
               handleTextSend();
             },
             keyboardType: TextInputType.multiline,
-            maxLines: null,
+            maxLines: 2,
           ),
         ),
       ],

--- a/lib/modules/chat/view/widgets/chat_input_wrap.dart
+++ b/lib/modules/chat/view/widgets/chat_input_wrap.dart
@@ -1,0 +1,162 @@
+import 'package:book/common/components/text_field/search_text_field.dart';
+import 'package:book/common/theme/style/app_paddings.dart';
+import 'package:book/common/theme/style/app_texts.dart';
+import 'package:book/gen/assets.gen.dart';
+import 'package:book/gen/colors.gen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+class ChatInputWrap extends ConsumerWidget {
+  final TextEditingController textController;
+  final bool visibleOption;
+  final Function(bool) updateVisibleOption;
+  final Function() handleTextSend;
+  final Function(ImageSource) clickInputOption;
+  final FocusNode focusNode;
+
+  const ChatInputWrap({
+    super.key,
+    required this.textController,
+    required this.visibleOption,
+    required this.updateVisibleOption,
+    required this.handleTextSend,
+    required this.clickInputOption,
+    required this.focusNode,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Container(
+      height: !visibleOption ? 129 : 129 + 249,
+      decoration: BoxDecoration(
+        color: ColorName.g7,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(20),
+          topRight: Radius.circular(20),
+        ),
+      ),
+      child: Padding(
+        padding: AppPaddings.CHAT_INPUT_PADDING,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            _buildChatInput(
+              textController,
+              visibleOption,
+              updateVisibleOption,
+              handleTextSend,
+              focusNode,
+            ),
+            if (visibleOption) _buildChatInputOption(clickInputOption)
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChatInput(
+      TextEditingController textController,
+      bool visibleOption,
+      Function(bool) updateVisibleOption,
+      Function() handleTextSend,
+      FocusNode focusNode) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        GestureDetector(
+          child: !visibleOption
+              ? Assets.icons.icBookpickChatOption.svg()
+              : Icon(Icons.close),
+          onTap: () {
+            updateVisibleOption(!visibleOption);
+          },
+        ),
+        SizedBox(
+          width: 24,
+        ),
+        Expanded(
+          child: SearchTextField(
+            focusNode: focusNode,
+            controller: textController,
+            backgroundColor: ColorName.w1,
+            textColor: ColorName.b1,
+            hintText: '메세지를 작성해 보세요',
+            hintStyle: AppTexts.b8.copyWith(color: ColorName.g3),
+            suffixIcon: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 13),
+              child: textController.text.isNotEmpty
+                  ? Assets.icons.icBookpickChatSendColored
+                      .svg(width: 22, height: 22)
+                  : Assets.icons.icBookpickChatSendDisabled
+                      .svg(width: 22, height: 22),
+            ),
+            onTap: () {
+              updateVisibleOption(false);
+            },
+            onTapSuffixIcon: () {
+              handleTextSend();
+            },
+            keyboardType: TextInputType.multiline,
+            maxLines: null,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChatInputOption(Function(ImageSource) clickInputOption) {
+    return Expanded(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              _buildOptionButton(
+                  "카메라", Assets.icons.icCamera.svg(width: 27, height: 27), () {
+                clickInputOption(ImageSource.camera);
+              }),
+              _buildOptionButton(
+                  "갤러리",
+                  Assets.icons.icBookpickChatOptionPicture
+                      .svg(width: 24, height: 24), () {
+                clickInputOption(ImageSource.gallery);
+              })
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOptionButton(
+    String text,
+    Widget icon,
+    Function() onTap,
+  ) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        children: [
+          Container(
+              width: 55,
+              height: 55,
+              decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(38.5),
+                  color: ColorName.dim2),
+              child: Center(child: icon)),
+          SizedBox(
+            height: 6,
+          ),
+          Text(
+            text,
+            style: AppTexts.b8.copyWith(color: ColorName.g2),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/modules/chat/view/widgets/chat_text_field.dart
+++ b/lib/modules/chat/view/widgets/chat_text_field.dart
@@ -1,0 +1,91 @@
+import 'package:book/common/theme/style/app_texts.dart';
+import 'package:book/gen/colors.gen.dart';
+import 'package:flutter/material.dart';
+
+class ChatTextField extends StatelessWidget {
+  final TextEditingController? controller;
+  final Widget? suffixIcon;
+
+  final String? hintText;
+  final TextStyle? hintStyle;
+  final Color? textColor;
+  final Color backgroundColor;
+  final Color focusColor;
+  final Color color;
+  final double borderRadius;
+  final double height;
+  final bool readOnly;
+  final void Function(String)? onSubmitted;
+  final VoidCallback? onTapSuffixIcon;
+  final VoidCallback? onTap;
+  final TextInputType? keyboardType;
+  final int? minLines;
+  final int? maxLines;
+  final FocusNode? focusNode;
+
+  const ChatTextField({
+    super.key,
+    this.controller,
+    this.suffixIcon,
+    this.hintText,
+    this.hintStyle = AppTexts.b6,
+    this.textColor,
+    this.backgroundColor = ColorName.g7,
+    this.focusColor = ColorName.p1,
+    this.color = ColorName.g3,
+    this.borderRadius = 8,
+    this.height = 48,
+    this.readOnly = false,
+    this.onSubmitted,
+    this.onTapSuffixIcon,
+    this.onTap,
+    this.keyboardType,
+    this.minLines = 1,
+    this.maxLines = 1,
+    this.focusNode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final outlineInputBorder = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(borderRadius),
+      borderSide: BorderSide(
+        color: (controller?.text.isNotEmpty ?? false) ? focusColor : color,
+      ),
+    );
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        minHeight: 0,
+        maxHeight: 100
+      ),
+      child: TextField(
+        focusNode: focusNode,
+        controller: controller,
+        onTap: onTap,
+        style: TextStyle(
+          color: textColor,
+        ),
+        decoration: InputDecoration(
+          hintText: hintText,
+          hintStyle: hintStyle,
+          suffixIcon: GestureDetector(
+            onTap: controller?.text.isNotEmpty ?? false ? onTapSuffixIcon : null,
+            child: suffixIcon,
+          ),
+          fillColor: backgroundColor,
+          border: outlineInputBorder,
+          disabledBorder: outlineInputBorder,
+          enabledBorder: outlineInputBorder,
+          focusedBorder: outlineInputBorder,
+          filled: true,
+        ),
+        onSubmitted: onSubmitted,
+        readOnly: readOnly,
+        keyboardType: keyboardType,
+        minLines: minLines,
+        maxLines: maxLines,
+      ),
+    );
+  }
+}

--- a/lib/modules/reading_challenge/view/widgets/ongoing_challenge_card.dart
+++ b/lib/modules/reading_challenge/view/widgets/ongoing_challenge_card.dart
@@ -32,66 +32,61 @@ class OngoingChallengeCard extends StatelessWidget {
             },
           );
           context.push(uri.toString());
+        } else {
+          onToggle();
         }
       },
-      child:GestureDetector(
-        onTap: () {
-          if (isSelectionMode) {
-            onToggle();
-          }
-        },
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(8),
-          child: AspectRatio(
-            aspectRatio: 2 / 3,
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                CachedNetworkImage(
-                  imageUrl: challenge.book.thumbnailUrl,
-                  fit: BoxFit.cover,
-                  errorWidget: (context, url, error) => const Icon(Icons.error),
-                ),
-                // Gradient for text readability
-                Positioned.fill(
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          Colors.transparent,
-                          Colors.black.withOpacity(0.1),
-                          Colors.black.withOpacity(0.8),
-                        ],
-                        stops: const [0.6, 0.8, 1.0],
-                      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: AspectRatio(
+          aspectRatio: 2 / 3,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              CachedNetworkImage(
+                imageUrl: challenge.book.thumbnailUrl,
+                fit: BoxFit.cover,
+                errorWidget: (context, url, error) => const Icon(Icons.error),
+              ),
+              // Gradient for text readability
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        Colors.transparent,
+                        Colors.black.withOpacity(0.1),
+                        Colors.black.withOpacity(0.8),
+                      ],
+                      stops: const [0.6, 0.8, 1.0],
                     ),
                   ),
                 ),
-                // Title text
-                Positioned(
-                  bottom: 8,
-                  left: 8,
-                  right: 8,
-                  child: Text(
-                    challenge.book.title,
-                    style: AppTexts.b7.copyWith(color: Colors.white),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
+              ),
+              // Title text
+              Positioned(
+                bottom: 8,
+                left: 8,
+                right: 8,
+                child: Text(
+                  challenge.book.title,
+                  style: AppTexts.b7.copyWith(color: Colors.white),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
                 ),
-                if (isSelectionMode)
-                  Positioned(
-                      top: 11,
-                      right: 8,
-                      child: CheckBox1(
-                        value: isSelected,
-                        onChanged: (bool value) => onToggle(),
-                      )
-                  )
-              ],
-            ),
+              ),
+              if (isSelectionMode)
+                Positioned(
+                    top: 11,
+                    right: 8,
+                    child: CheckBox1(
+                      value: isSelected,
+                      onChanged: (bool value) => onToggle(),
+                    )
+                )
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
Fixes #56
Fixes #57

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. 예: Fixes #123 -->

---

**변경사항**
[Feat] #56 책톡:채팅 키보드 제어 
- ChatInputWrap widget으로 별도 작성
- 외부 클릭시 키보드, 첨부파일 화면 hide
- 채팅 input 클릭시 키보드 표시
- 첨부파일 버튼 클릭시 키보드 hide
- 첨부파일 화면 표시 중 채팅 input 클릭시 첨부파일 hide, 키보드 show
- SearchTextField 카피용 ChatTextField 작성 및 maxHeight 적용
[Feat] #57 리딩챌린지:완독 도서 화면, 도서 클릭시 도서 상세로 이동 
- `GestureDetector` 중복 정의 제거

<!-- 주요 변경사항을 간단히 설명해주세요. -->

---

**스크린샷**

| Before | After |
|--------|-------|
|        |       |

<!-- 변경 전/후 스크린샷을 첨부해주세요. 필요시 이미지를 드래그&드롭 하세요. -->