### PR TITLE
update for deep time refleting QA feedbacks

### DIFF
--- a/lib/modules/deep_time/view/widgets/deep_time_completion_dialog.dart
+++ b/lib/modules/deep_time/view/widgets/deep_time_completion_dialog.dart
@@ -1,9 +1,8 @@
 import 'package:book/gen/assets.gen.dart';
-import 'package:book/modules/deep_time/view_model/deep_time_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
 import '../../../../common/components/dialog/custom_dialog.dart';
+import 'package:go_router/go_router.dart';
 
 class DeepTimeCompletionDialog extends ConsumerWidget {
   const DeepTimeCompletionDialog({super.key});
@@ -17,14 +16,15 @@ class DeepTimeCompletionDialog extends ConsumerWidget {
       cancelButtonText: '다시 하기',
       icon: Assets.icons.icDeeptypeNotification2.svg(width: 100),
       onConfirm: () {
-        // TODO: Navigate to reading challenge screen
+        if (!context.mounted) return;
         Navigator.of(context).pop();
+        Navigator.of(context).pop();
+        context.go('/reading-challenge/');
       },
-      onCancel: () async {
-        await ref.read(deepTimeViewModelProvider.notifier).resetTimer();
-        if (context.mounted) {
-          Navigator.of(context).pop();
-        }
+      onCancel: () {
+        if (!context.mounted) return;
+        Navigator.of(context).pop();
+        Navigator.of(context).pop();
       },
     );
   }

--- a/lib/modules/deep_time/view/widgets/playlist_button.dart
+++ b/lib/modules/deep_time/view/widgets/playlist_button.dart
@@ -19,15 +19,6 @@ class PlaylistButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<MusicItem?>(selectedMusicProvider, (previous, next) {
-      if (next != null) {
-        final audioPlayer = ref.read(audioPlayerProvider);
-        initAudioSession();
-        audioPlayer.setUrl(next.musicUrl);
-        audioPlayer.play();
-      }
-    });
-
     return CtaButtonL1(
       text: '플레이 리스트',
       onPressed: () async {
@@ -41,8 +32,6 @@ class PlaylistButton extends ConsumerWidget {
             return showBottom(context);
           },
         );
-
-        ref.read(selectedMusicProvider.notifier).state = null;
       },
     );
   }
@@ -86,10 +75,6 @@ class PlaylistButton extends ConsumerWidget {
                 // SearchField(context),
               ],
             ),
-          ),
-          Padding(
-            padding: EdgeInsetsGeometry.symmetric(horizontal: 16),
-            child: Divider(),
           ),
           const SizedBox(height: 8),
           Consumer(

--- a/lib/modules/deep_time/view_model/deep_time_view_model.dart
+++ b/lib/modules/deep_time/view_model/deep_time_view_model.dart
@@ -7,14 +7,14 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'deep_time_view_model.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 class DeepTimeViewModel extends _$DeepTimeViewModel {
   Timer? _timer;
 
   @override
   Future<DeepTimeState> build() async {
     final repo = ref.read(deepTimeRepositoryProvider);
-    
+
     // Notifier가 dispose될 때 타이머를 취소합니다.
     ref.onDispose(() {
       _timer?.cancel();
@@ -33,8 +33,7 @@ class DeepTimeViewModel extends _$DeepTimeViewModel {
       final repo = ref.read(deepTimeRepositoryProvider);
       final response = await repo.getTodayTimer();
       state = AsyncData(
-        originalState.copyWith(
-            todayTotalSeconds: response.data.totalSeconds),
+        originalState.copyWith(todayTotalSeconds: response.data.totalSeconds),
       );
     } catch (e) {
       state = AsyncData(originalState.copyWith(errorMessage: e.toString()));
@@ -48,10 +47,12 @@ class DeepTimeViewModel extends _$DeepTimeViewModel {
     final newState = state.value?.copyWith(
       settingDuration: duration,
       remainingDuration: duration,
-      status: duration == Duration.zero ? DeepTimeStatus.initial : DeepTimeStatus.ready,
+      status: duration == Duration.zero
+          ? DeepTimeStatus.initial
+          : DeepTimeStatus.ready,
     );
-    if(newState != null){
-       state = AsyncData(newState);
+    if (newState != null) {
+      state = AsyncData(newState);
     }
   }
 
@@ -66,7 +67,7 @@ class DeepTimeViewModel extends _$DeepTimeViewModel {
     _timer?.cancel();
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
       final currentVal = state.value;
-      if(currentVal == null) {
+      if (currentVal == null) {
         timer.cancel();
         return;
       }
@@ -101,10 +102,10 @@ class DeepTimeViewModel extends _$DeepTimeViewModel {
     if (state.value != null && state.value!.settingDuration.inSeconds > 0) {
       await _postTimerDuration();
     }
-    
+
     final currentVal = state.value;
-    if(currentVal != null) {
-       state = AsyncData(
+    if (currentVal != null) {
+      state = AsyncData(
         currentVal.copyWith(
           status: DeepTimeStatus.initial,
           remainingDuration: Duration.zero,
@@ -117,15 +118,16 @@ class DeepTimeViewModel extends _$DeepTimeViewModel {
   // 서버에 시간 기록
   Future<void> _postTimerDuration() async {
     final currentVal = state.value;
-    if(currentVal == null || currentVal.settingDuration.inSeconds == 0) return;
-    
+    if (currentVal == null || currentVal.settingDuration.inSeconds == 0) return;
+
     try {
       final repo = ref.read(deepTimeRepositoryProvider);
       final recordedSeconds = currentVal.settingDuration.inSeconds -
           currentVal.remainingDuration.inSeconds;
 
       // settingDuration을 초기화해서 중복 기록 방지
-      final newState = currentVal.copyWith(settingDuration: Duration.zero, remainingDuration: Duration.zero);
+      final newState = currentVal.copyWith(
+          settingDuration: Duration.zero, remainingDuration: Duration.zero);
       state = AsyncData(newState);
 
       if (recordedSeconds > 0) {
@@ -136,8 +138,8 @@ class DeepTimeViewModel extends _$DeepTimeViewModel {
     } catch (e) {
       final originalState = state.value;
       if (originalState != null) {
-         state = AsyncData(originalState.copyWith(errorMessage: e.toString()));
+        state = AsyncData(originalState.copyWith(errorMessage: e.toString()));
       }
     }
   }
-} 
+}

--- a/lib/modules/home/view/widgets/home_app_bar.dart
+++ b/lib/modules/home/view/widgets/home_app_bar.dart
@@ -22,15 +22,6 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     final label = HomeBottomNavMenu.values[currentIndex].label;
-    final isDeepTime = currentIndex == HomeBottomNavMenu.deepTime.index;
-
-    if (isDeepTime) {
-      return AppBar(
-        automaticallyImplyLeading: false,
-        title: Text('딥타임', style: AppTexts.b5),
-        centerTitle: true,
-      );
-    }
 
     return AppBar(
       automaticallyImplyLeading: false,


### PR DESCRIPTION
Fixes #92

---

제가 생각하기에 중요도 우선시 되는 친구들 먼저 시작했습니다.

딥타임: 개선: 플레이리스트 버튼에 타이머쪽 ui가 안보임
-> relative에서 absolute로 바꿨습니다. 아이폰 12미니에서는 잘 보입니다.

딥타임: 개선: 딥타임 메인화면 - 왼쪽위에 닫기버튼 있음. 삭제필요
-> LeadingIcon지움

딥타임: 개선: 타이머 중에는 기획의도와 맞게 다른 화면으로 이동하지 못하게 하는 것이 어떨까요?
-> home_screen.dart에서 deep_time화면일 경우 아래 navigation bar disable하였습니다.

딥타임: 개선: 타이머 진행 시 생기는 하단 그라데이션의 좌우 경계를 없앨 수 있을까요? 사소한 부분이긴 하지만 해결 된다면 훨씬 보기 좋을 것 같습니다
-> 이것도 deep_time이면 왼/오 패딩을 zero로 바꾸었습니다.

딥타임: 개선: 딥타임 타이머 종료 후 리딩챌린지 작성하기를 눌러도 리딩 챌린지로 넘어가지 않습니다.
-> 해당 로직 구현했습니다. 신기하게 context.pop을 두번해야 dialog가 사라지던데 (대부분 한번하면 사라짐) 이건 나중에 디버깅이 혹시 모르니 필요할 거 같습니다.

** 아래 2개를 합쳐서 그냥 음악이 끝나면 해당 음악 시작으로 무한 반복이 되도록 했습니다. 타이머 시간마다 대신 무한루프입니다.
딥타임: 개선: 노래가 타이머 시간 만큼 반복 재생이 되지 않음(1시간 동안)
딥타임: 개선: 플레이리스트 노래 시간 넘기기 스크롤이 자연스럽지않음 + 다시 재생 및 무한 반복 있었으면 함

** Music scope가 bottomsheet에서만 적용 -> global하게 적용으로 바뀌었습니다
---

**스크린샷** -> 프론트쪽에서의 변화가 적으나 로직측면에서의 업뎃이 많습니다.
