### PR TITLE
if screen height is below 800, use smaller size for text and circleTimer

### DIFF
--- a/lib/modules/deep_time/view/screens/deep_time_screen.dart
+++ b/lib/modules/deep_time/view/screens/deep_time_screen.dart
@@ -83,6 +83,9 @@ class _DeepTimeScreenState extends ConsumerState<DeepTimeScreen> {
             ? state.remainingDuration
             : state.settingDuration;
 
+    final circularTimerSize =
+        MediaQuery.of(context).size.height > 800.0 ? 272.0 : 250.0;
+
     return PopScope(
       // followed by modification in lib/modules/home/view/screens/home_screen.dart.
       // if DeepTimeStatus.running -> can't use bottom navigator bar.
@@ -94,15 +97,15 @@ class _DeepTimeScreenState extends ConsumerState<DeepTimeScreen> {
               mainAxisAlignment: MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                const SizedBox(height: 30),
+                const SizedBox(height: 20),
                 SizedBox(
-                  width: 272,
-                  height: 272,
+                  width: circularTimerSize,
+                  height: circularTimerSize,
                   child: Stack(
                     alignment: Alignment.center,
                     clipBehavior: Clip.none,
                     children: [
-                      CircularTimer(size: 272),
+                      CircularTimer(size: circularTimerSize),
                       _buildTimeMarker('0', const Alignment(0, -0.85)),
                       _buildTimeMarker('15', const Alignment(0.85, 0)),
                       _buildTimeMarker('30', const Alignment(0, 0.85)),
@@ -116,29 +119,27 @@ class _DeepTimeScreenState extends ConsumerState<DeepTimeScreen> {
                 // time is zero
                 if (displayDuration == Duration.zero) ...[
                   _buildStatusText(status, displayDuration),
-                  const SizedBox(height: 30),
+                  const SizedBox(height: 20),
                   _buildTodayTotalTime(state.todayTotalSeconds),
                 ],
                 // time is not zero
                 if (state.settingDuration > Duration.zero) ...[
                   const TimerControls(),
-                  const SizedBox(height: 20),
                 ],
 
                 // 00:00 time display
                 _TimerDisplay(
                   status: status,
                   displayDuration: displayDuration,
+                  circleSize: circularTimerSize,
                 ),
               ],
             ),
-
-            // need to have bottom-fixed padding so that it doesn't change its position based on the top widgets' heights
             Align(
               alignment: Alignment.bottomCenter,
               child: Padding(
                 padding: EdgeInsets.only(
-                  bottom: 26.0 + MediaQuery.of(context).viewPadding.bottom,
+                  bottom: 12.0,
                 ),
                 child: PlaylistButton(),
               ),
@@ -167,11 +168,13 @@ class _DeepTimeScreenState extends ConsumerState<DeepTimeScreen> {
       text = '시간을 돌려 설정해 보세요';
     }
 
-    return Text(
-      text,
-      style: AppTexts.b6.copyWith(color: ColorName.g4),
-      textAlign: TextAlign.center,
-    );
+    return SizedBox(
+        height: 24,
+        child: Text(
+          text,
+          style: AppTexts.b6.copyWith(color: ColorName.g4),
+          textAlign: TextAlign.center,
+        ));
   }
 
   Widget _buildTodayTotalTime(int totalSeconds) {
@@ -211,13 +214,14 @@ class _DeepTimeScreenState extends ConsumerState<DeepTimeScreen> {
 }
 
 class _TimerDisplay extends StatelessWidget {
-  const _TimerDisplay({
-    required this.status,
-    required this.displayDuration,
-  });
+  const _TimerDisplay(
+      {required this.status,
+      required this.displayDuration,
+      required this.circleSize});
 
   final DeepTimeStatus status;
   final Duration displayDuration;
+  final double circleSize;
 
   @override
   Widget build(BuildContext context) {
@@ -234,16 +238,22 @@ class _TimerDisplay extends StatelessWidget {
     );
 
     if (status != DeepTimeStatus.running) {
-      return Text(
-        FormatUtils.formatDuration(displayDuration),
-        style: timerTextStyle.copyWith(
-          color: ColorName.g5,
+      return SizedBox(
+        height: circleSize < 270 ? 65 : 90,
+        child: FittedBox(
+          fit: BoxFit.cover,
+          child: Text(
+            FormatUtils.formatDuration(displayDuration),
+            style: timerTextStyle.copyWith(
+              color: ColorName.g5,
+            ),
+          ),
         ),
       );
     }
 
-    return SizedBox(
-      height: 80,
+    return Container(
+      height: circleSize < 270 ? 85 : 120,
       width: 250,
       child: Stack(
         alignment: Alignment.center,
@@ -267,7 +277,10 @@ class _TimerDisplay extends StatelessWidget {
               ),
             ),
           ),
-          timerText,
+          SizedBox(
+            height: circleSize < 270 ? 65 : 90,
+            child: FittedBox(fit: BoxFit.cover, child: timerText),
+          ),
           Positioned(
             left: -10,
             top: -5,

--- a/lib/modules/deep_time/view/widgets/playlist_button.dart
+++ b/lib/modules/deep_time/view/widgets/playlist_button.dart
@@ -19,20 +19,24 @@ class PlaylistButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return CtaButtonL1(
-      text: '플레이 리스트',
-      onPressed: () async {
-        await showModalBottomSheet(
-          useSafeArea: true,
-          isScrollControlled: true,
-          backgroundColor: Colors.transparent,
-          useRootNavigator: true,
-          context: context,
-          builder: (context) {
-            return showBottom(context);
-          },
-        );
-      },
+    return SizedBox(
+      height: 56,
+      width: 341,
+      child: CtaButtonL1(
+        text: '플레이 리스트',
+        onPressed: () async {
+          await showModalBottomSheet(
+            useSafeArea: true,
+            isScrollControlled: true,
+            backgroundColor: Colors.transparent,
+            useRootNavigator: true,
+            context: context,
+            builder: (context) {
+              return showBottom(context);
+            },
+          );
+        },
+      ),
     );
   }
 
@@ -47,65 +51,71 @@ class PlaylistButton extends ConsumerWidget {
       ),
       width: MediaQuery.of(context).size.width,
       height: 568,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const SizedBox(height: 25),
-          Padding(
-            padding: const EdgeInsets.only(left: 16),
-            child: SizedBox(
-              width: 30,
-              height: 30,
-              child: IconButton(
-                alignment: Alignment.centerLeft,
-                padding: EdgeInsets.zero,
-                iconSize: 24,
-                icon: const BackButton(color: ColorName.g3),
-                onPressed: () => Navigator.of(context).pop(),
+      child: Stack(children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 25),
+            Padding(
+              padding: const EdgeInsets.only(left: 16),
+              child: SizedBox(
+                width: 30,
+                height: 30,
+                child: IconButton(
+                  alignment: Alignment.centerLeft,
+                  padding: EdgeInsets.zero,
+                  iconSize: 24,
+                  icon: const BackButton(color: ColorName.g3),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
               ),
             ),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(left: 16, top: 25),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text("플레이 리스트", style: AppTexts.b3),
-                const SizedBox(height: 16),
-                // SearchField(context),
-              ],
+            Padding(
+              padding: const EdgeInsets.only(left: 16, top: 25),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text("플레이 리스트", style: AppTexts.b3),
+                  const SizedBox(height: 16),
+                  // SearchField(context),
+                ],
+              ),
             ),
-          ),
-          const SizedBox(height: 8),
-          Consumer(
-            builder: (context, ref, child) {
-              final playlist = ref.watch(playlistProvider);
-              final selectedMusic = ref.watch(selectedMusicProvider);
+            const SizedBox(height: 8),
+            Consumer(
+              builder: (context, ref, child) {
+                final playlist = ref.watch(playlistProvider);
+                final selectedMusic = ref.watch(selectedMusicProvider);
 
-              return SizedBox(
-                height: 286,
-                child: ListView.separated(
-                  separatorBuilder: (context, index) =>
-                      const Divider(height: 1, color: ColorName.g7),
-                  shrinkWrap: true,
-                  itemCount: playlist.length,
-                  itemBuilder: (context, index) {
-                    final music = playlist[index];
-                    final isSelected = selectedMusic?.id == music.id;
-                    return MusicInfo(
-                      context: context,
-                      music: music,
-                      isSelected: isSelected,
-                    );
-                  },
-                ),
-              );
-            },
-          ),
-          const SizedBox(height: 12),
-          const Center(child: MusicPlayerWidget()),
-        ],
-      ),
+                return SizedBox(
+                  height: 286,
+                  child: ListView.separated(
+                    separatorBuilder: (context, index) =>
+                        const Divider(height: 1, color: ColorName.g7),
+                    shrinkWrap: true,
+                    itemCount: playlist.length,
+                    itemBuilder: (context, index) {
+                      final music = playlist[index];
+                      final isSelected = selectedMusic?.id == music.id;
+                      return MusicInfo(
+                        context: context,
+                        music: music,
+                        isSelected: isSelected,
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 12),
+          ],
+        ),
+        const Align(
+            alignment: Alignment.bottomCenter,
+            child: Padding(
+                padding: EdgeInsetsGeometry.only(bottom: 18),
+                child: MusicPlayerWidget())),
+      ]),
     );
   }
 

--- a/lib/modules/deep_time/view/widgets/timer_controls.dart
+++ b/lib/modules/deep_time/view/widgets/timer_controls.dart
@@ -10,9 +10,6 @@ class TimerControls extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final screenWidth = MediaQuery.of(context).size.width;
-    final iconSize = screenWidth * 0.18;
-
     final state = ref.watch(deepTimeViewModelProvider).value;
     if (state == null) {
       return const SizedBox.shrink();
@@ -52,17 +49,26 @@ class TimerControls extends ConsumerWidget {
           return ScaleTransition(scale: animation, child: child);
         },
         child: isRunning
-            ? Icon(
-                Icons.pause_circle_filled,
-                key: const ValueKey('pause'),
-                color: ColorName.p1,
-                size: iconSize,
-              )
-            : Icon(
-                Icons.play_circle_filled,
-                key: const ValueKey('play'),
-                color: isSetting ? ColorName.g5 : ColorName.p1,
-                size: iconSize,
+            ? Container(
+                padding: const EdgeInsets.all(0.0),
+                width: 66.0, // you can adjust the width as you need
+                height: 66,
+                child: Icon(
+                  Icons.pause_circle_filled,
+                  key: const ValueKey('pause'),
+                  color: ColorName.p1,
+                  size: 66,
+                ))
+            : Container(
+                padding: const EdgeInsets.all(0.0),
+                width: 66.0, // you can adjust the width as you need
+                height: 66,
+                child: Icon(
+                  Icons.play_circle_filled,
+                  key: const ValueKey('play'),
+                  color: isSetting ? ColorName.g5 : ColorName.p1,
+                  size: 66,
+                ),
               ),
       ),
     );


### PR DESCRIPTION
Fixes #

미니 휴대폰의 height이 기존 Figma pixel을 못따라오는 경우가 있어
mediaquery로 만약 height가 800 아래일 경우(2022년 버전들) CircleTimer Size와 timer 00:00텍스트 사이즈 축소,
또 playlistButton내 music player를 align써서 bottom-fixed with padding으로 변경
---
