### PR TITLE
#166 팔로잉 피드 다 봤을 때 개인화 피드 이어붙이기

### DIFF
--- a/lib/common/models/image_request.freezed.dart
+++ b/lib/common/models/image_request.freezed.dart
@@ -246,7 +246,7 @@ extension ImageRequestPatterns on ImageRequest {
 /// @nodoc
 @JsonSerializable()
 class _ImageRequest implements ImageRequest {
-  const _ImageRequest({this.imageUrl = "", this.sequence = 0});
+  const _ImageRequest({this.imageUrl = "", this.sequence = 1});
   factory _ImageRequest.fromJson(Map<String, dynamic> json) =>
       _$ImageRequestFromJson(json);
 

--- a/lib/common/models/image_request.g.dart
+++ b/lib/common/models/image_request.g.dart
@@ -9,7 +9,7 @@ part of 'image_request.dart';
 _ImageRequest _$ImageRequestFromJson(Map<String, dynamic> json) =>
     _ImageRequest(
       imageUrl: json['imageUrl'] as String? ?? "",
-      sequence: (json['sequence'] as num?)?.toInt() ?? 0,
+      sequence: (json['sequence'] as num?)?.toInt() ?? 1,
     );
 
 Map<String, dynamic> _$ImageRequestToJson(_ImageRequest instance) =>

--- a/lib/modules/book_log/state/book_log_state.dart
+++ b/lib/modules/book_log/state/book_log_state.dart
@@ -11,8 +11,10 @@ abstract class BookLogState with _$BookLogState {
     @Default(ProfileWithCounts()) ProfileWithCounts profile,
     @Default([]) List<DiaryThumbnail> thumbnails,
     @Default([]) List<DiaryResponse> feeds,
-    @Default(false) bool hasNext,
-    @Default(-1) int nextCursor,
+    @Default(false) bool feedHasNext,
+    @Default(-1) int feedNextCursor,
+    @Default(false) bool personalizedFeedHasNext,
+    @Default(-1) int personalizedFeedNextCursor,
     int? memberId,
   }) = _BookLogState;
 }

--- a/lib/modules/book_log/state/book_log_state.freezed.dart
+++ b/lib/modules/book_log/state/book_log_state.freezed.dart
@@ -17,8 +17,10 @@ mixin _$BookLogState {
   ProfileWithCounts get profile;
   List<DiaryThumbnail> get thumbnails;
   List<DiaryResponse> get feeds;
-  bool get hasNext;
-  int get nextCursor;
+  bool get feedHasNext;
+  int get feedNextCursor;
+  bool get personalizedFeedHasNext;
+  int get personalizedFeedNextCursor;
   int? get memberId;
 
   /// Create a copy of BookLogState
@@ -38,9 +40,17 @@ mixin _$BookLogState {
             const DeepCollectionEquality()
                 .equals(other.thumbnails, thumbnails) &&
             const DeepCollectionEquality().equals(other.feeds, feeds) &&
-            (identical(other.hasNext, hasNext) || other.hasNext == hasNext) &&
-            (identical(other.nextCursor, nextCursor) ||
-                other.nextCursor == nextCursor) &&
+            (identical(other.feedHasNext, feedHasNext) ||
+                other.feedHasNext == feedHasNext) &&
+            (identical(other.feedNextCursor, feedNextCursor) ||
+                other.feedNextCursor == feedNextCursor) &&
+            (identical(
+                    other.personalizedFeedHasNext, personalizedFeedHasNext) ||
+                other.personalizedFeedHasNext == personalizedFeedHasNext) &&
+            (identical(other.personalizedFeedNextCursor,
+                    personalizedFeedNextCursor) ||
+                other.personalizedFeedNextCursor ==
+                    personalizedFeedNextCursor) &&
             (identical(other.memberId, memberId) ||
                 other.memberId == memberId));
   }
@@ -51,13 +61,15 @@ mixin _$BookLogState {
       profile,
       const DeepCollectionEquality().hash(thumbnails),
       const DeepCollectionEquality().hash(feeds),
-      hasNext,
-      nextCursor,
+      feedHasNext,
+      feedNextCursor,
+      personalizedFeedHasNext,
+      personalizedFeedNextCursor,
       memberId);
 
   @override
   String toString() {
-    return 'BookLogState(profile: $profile, thumbnails: $thumbnails, feeds: $feeds, hasNext: $hasNext, nextCursor: $nextCursor, memberId: $memberId)';
+    return 'BookLogState(profile: $profile, thumbnails: $thumbnails, feeds: $feeds, feedHasNext: $feedHasNext, feedNextCursor: $feedNextCursor, personalizedFeedHasNext: $personalizedFeedHasNext, personalizedFeedNextCursor: $personalizedFeedNextCursor, memberId: $memberId)';
   }
 }
 
@@ -71,8 +83,10 @@ abstract mixin class $BookLogStateCopyWith<$Res> {
       {ProfileWithCounts profile,
       List<DiaryThumbnail> thumbnails,
       List<DiaryResponse> feeds,
-      bool hasNext,
-      int nextCursor,
+      bool feedHasNext,
+      int feedNextCursor,
+      bool personalizedFeedHasNext,
+      int personalizedFeedNextCursor,
       int? memberId});
 
   $ProfileWithCountsCopyWith<$Res> get profile;
@@ -93,8 +107,10 @@ class _$BookLogStateCopyWithImpl<$Res> implements $BookLogStateCopyWith<$Res> {
     Object? profile = null,
     Object? thumbnails = null,
     Object? feeds = null,
-    Object? hasNext = null,
-    Object? nextCursor = null,
+    Object? feedHasNext = null,
+    Object? feedNextCursor = null,
+    Object? personalizedFeedHasNext = null,
+    Object? personalizedFeedNextCursor = null,
     Object? memberId = freezed,
   }) {
     return _then(_self.copyWith(
@@ -110,13 +126,21 @@ class _$BookLogStateCopyWithImpl<$Res> implements $BookLogStateCopyWith<$Res> {
           ? _self.feeds
           : feeds // ignore: cast_nullable_to_non_nullable
               as List<DiaryResponse>,
-      hasNext: null == hasNext
-          ? _self.hasNext
-          : hasNext // ignore: cast_nullable_to_non_nullable
+      feedHasNext: null == feedHasNext
+          ? _self.feedHasNext
+          : feedHasNext // ignore: cast_nullable_to_non_nullable
               as bool,
-      nextCursor: null == nextCursor
-          ? _self.nextCursor
-          : nextCursor // ignore: cast_nullable_to_non_nullable
+      feedNextCursor: null == feedNextCursor
+          ? _self.feedNextCursor
+          : feedNextCursor // ignore: cast_nullable_to_non_nullable
+              as int,
+      personalizedFeedHasNext: null == personalizedFeedHasNext
+          ? _self.personalizedFeedHasNext
+          : personalizedFeedHasNext // ignore: cast_nullable_to_non_nullable
+              as bool,
+      personalizedFeedNextCursor: null == personalizedFeedNextCursor
+          ? _self.personalizedFeedNextCursor
+          : personalizedFeedNextCursor // ignore: cast_nullable_to_non_nullable
               as int,
       memberId: freezed == memberId
           ? _self.memberId
@@ -233,8 +257,10 @@ extension BookLogStatePatterns on BookLogState {
             ProfileWithCounts profile,
             List<DiaryThumbnail> thumbnails,
             List<DiaryResponse> feeds,
-            bool hasNext,
-            int nextCursor,
+            bool feedHasNext,
+            int feedNextCursor,
+            bool personalizedFeedHasNext,
+            int personalizedFeedNextCursor,
             int? memberId)?
         $default, {
     required TResult orElse(),
@@ -242,8 +268,15 @@ extension BookLogStatePatterns on BookLogState {
     final _that = this;
     switch (_that) {
       case _BookLogState() when $default != null:
-        return $default(_that.profile, _that.thumbnails, _that.feeds,
-            _that.hasNext, _that.nextCursor, _that.memberId);
+        return $default(
+            _that.profile,
+            _that.thumbnails,
+            _that.feeds,
+            _that.feedHasNext,
+            _that.feedNextCursor,
+            _that.personalizedFeedHasNext,
+            _that.personalizedFeedNextCursor,
+            _that.memberId);
       case _:
         return orElse();
     }
@@ -268,16 +301,25 @@ extension BookLogStatePatterns on BookLogState {
             ProfileWithCounts profile,
             List<DiaryThumbnail> thumbnails,
             List<DiaryResponse> feeds,
-            bool hasNext,
-            int nextCursor,
+            bool feedHasNext,
+            int feedNextCursor,
+            bool personalizedFeedHasNext,
+            int personalizedFeedNextCursor,
             int? memberId)
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _BookLogState():
-        return $default(_that.profile, _that.thumbnails, _that.feeds,
-            _that.hasNext, _that.nextCursor, _that.memberId);
+        return $default(
+            _that.profile,
+            _that.thumbnails,
+            _that.feeds,
+            _that.feedHasNext,
+            _that.feedNextCursor,
+            _that.personalizedFeedHasNext,
+            _that.personalizedFeedNextCursor,
+            _that.memberId);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -301,16 +343,25 @@ extension BookLogStatePatterns on BookLogState {
             ProfileWithCounts profile,
             List<DiaryThumbnail> thumbnails,
             List<DiaryResponse> feeds,
-            bool hasNext,
-            int nextCursor,
+            bool feedHasNext,
+            int feedNextCursor,
+            bool personalizedFeedHasNext,
+            int personalizedFeedNextCursor,
             int? memberId)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _BookLogState() when $default != null:
-        return $default(_that.profile, _that.thumbnails, _that.feeds,
-            _that.hasNext, _that.nextCursor, _that.memberId);
+        return $default(
+            _that.profile,
+            _that.thumbnails,
+            _that.feeds,
+            _that.feedHasNext,
+            _that.feedNextCursor,
+            _that.personalizedFeedHasNext,
+            _that.personalizedFeedNextCursor,
+            _that.memberId);
       case _:
         return null;
     }
@@ -324,8 +375,10 @@ class _BookLogState implements BookLogState {
       {this.profile = const ProfileWithCounts(),
       final List<DiaryThumbnail> thumbnails = const [],
       final List<DiaryResponse> feeds = const [],
-      this.hasNext = false,
-      this.nextCursor = -1,
+      this.feedHasNext = false,
+      this.feedNextCursor = -1,
+      this.personalizedFeedHasNext = false,
+      this.personalizedFeedNextCursor = -1,
       this.memberId})
       : _thumbnails = thumbnails,
         _feeds = feeds;
@@ -353,10 +406,16 @@ class _BookLogState implements BookLogState {
 
   @override
   @JsonKey()
-  final bool hasNext;
+  final bool feedHasNext;
   @override
   @JsonKey()
-  final int nextCursor;
+  final int feedNextCursor;
+  @override
+  @JsonKey()
+  final bool personalizedFeedHasNext;
+  @override
+  @JsonKey()
+  final int personalizedFeedNextCursor;
   @override
   final int? memberId;
 
@@ -377,9 +436,17 @@ class _BookLogState implements BookLogState {
             const DeepCollectionEquality()
                 .equals(other._thumbnails, _thumbnails) &&
             const DeepCollectionEquality().equals(other._feeds, _feeds) &&
-            (identical(other.hasNext, hasNext) || other.hasNext == hasNext) &&
-            (identical(other.nextCursor, nextCursor) ||
-                other.nextCursor == nextCursor) &&
+            (identical(other.feedHasNext, feedHasNext) ||
+                other.feedHasNext == feedHasNext) &&
+            (identical(other.feedNextCursor, feedNextCursor) ||
+                other.feedNextCursor == feedNextCursor) &&
+            (identical(
+                    other.personalizedFeedHasNext, personalizedFeedHasNext) ||
+                other.personalizedFeedHasNext == personalizedFeedHasNext) &&
+            (identical(other.personalizedFeedNextCursor,
+                    personalizedFeedNextCursor) ||
+                other.personalizedFeedNextCursor ==
+                    personalizedFeedNextCursor) &&
             (identical(other.memberId, memberId) ||
                 other.memberId == memberId));
   }
@@ -390,13 +457,15 @@ class _BookLogState implements BookLogState {
       profile,
       const DeepCollectionEquality().hash(_thumbnails),
       const DeepCollectionEquality().hash(_feeds),
-      hasNext,
-      nextCursor,
+      feedHasNext,
+      feedNextCursor,
+      personalizedFeedHasNext,
+      personalizedFeedNextCursor,
       memberId);
 
   @override
   String toString() {
-    return 'BookLogState(profile: $profile, thumbnails: $thumbnails, feeds: $feeds, hasNext: $hasNext, nextCursor: $nextCursor, memberId: $memberId)';
+    return 'BookLogState(profile: $profile, thumbnails: $thumbnails, feeds: $feeds, feedHasNext: $feedHasNext, feedNextCursor: $feedNextCursor, personalizedFeedHasNext: $personalizedFeedHasNext, personalizedFeedNextCursor: $personalizedFeedNextCursor, memberId: $memberId)';
   }
 }
 
@@ -412,8 +481,10 @@ abstract mixin class _$BookLogStateCopyWith<$Res>
       {ProfileWithCounts profile,
       List<DiaryThumbnail> thumbnails,
       List<DiaryResponse> feeds,
-      bool hasNext,
-      int nextCursor,
+      bool feedHasNext,
+      int feedNextCursor,
+      bool personalizedFeedHasNext,
+      int personalizedFeedNextCursor,
       int? memberId});
 
   @override
@@ -436,8 +507,10 @@ class __$BookLogStateCopyWithImpl<$Res>
     Object? profile = null,
     Object? thumbnails = null,
     Object? feeds = null,
-    Object? hasNext = null,
-    Object? nextCursor = null,
+    Object? feedHasNext = null,
+    Object? feedNextCursor = null,
+    Object? personalizedFeedHasNext = null,
+    Object? personalizedFeedNextCursor = null,
     Object? memberId = freezed,
   }) {
     return _then(_BookLogState(
@@ -453,13 +526,21 @@ class __$BookLogStateCopyWithImpl<$Res>
           ? _self._feeds
           : feeds // ignore: cast_nullable_to_non_nullable
               as List<DiaryResponse>,
-      hasNext: null == hasNext
-          ? _self.hasNext
-          : hasNext // ignore: cast_nullable_to_non_nullable
+      feedHasNext: null == feedHasNext
+          ? _self.feedHasNext
+          : feedHasNext // ignore: cast_nullable_to_non_nullable
               as bool,
-      nextCursor: null == nextCursor
-          ? _self.nextCursor
-          : nextCursor // ignore: cast_nullable_to_non_nullable
+      feedNextCursor: null == feedNextCursor
+          ? _self.feedNextCursor
+          : feedNextCursor // ignore: cast_nullable_to_non_nullable
+              as int,
+      personalizedFeedHasNext: null == personalizedFeedHasNext
+          ? _self.personalizedFeedHasNext
+          : personalizedFeedHasNext // ignore: cast_nullable_to_non_nullable
+              as bool,
+      personalizedFeedNextCursor: null == personalizedFeedNextCursor
+          ? _self.personalizedFeedNextCursor
+          : personalizedFeedNextCursor // ignore: cast_nullable_to_non_nullable
               as int,
       memberId: freezed == memberId
           ? _self.memberId

--- a/lib/modules/book_log/view_model/book_log_view_model.g.dart
+++ b/lib/modules/book_log/view_model/book_log_view_model.g.dart
@@ -6,7 +6,7 @@ part of 'book_log_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$bookLogViewModelHash() => r'0821ba0ca9ca2800aaf3296e3fd56fca1bcec174';
+String _$bookLogViewModelHash() => r'89ba17ff9115451dcc37e99f1e177e9c64e87bd9';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/modules/reading_diary/repository/reading_diary_repository.dart
+++ b/lib/modules/reading_diary/repository/reading_diary_repository.dart
@@ -74,6 +74,13 @@ abstract class ReadingDiaryRepository {
     @Query('size') int? size,
   });
 
+  @GET('/reading-diaries/following/personalized-feed')
+  Future<ResponseForm<CursorPageResponse<DiaryResponse>>>
+      getReadingDiariesMembersFollowingPersonalizedFeed({
+    @Query('cursor') int? cursor, // 서버 명세에 따라 파라미터 이름이 다를 수 있음
+    @Query('size') int? size,
+  });
+
   @GET('/reading-diaries/books/{bookId}')
   Future<ResponseForm<CursorPageResponse<DiaryResponse>>> getBookDiaries(
     @Path('bookId') int bookId, {

--- a/lib/modules/reading_diary/repository/reading_diary_repository.g.dart
+++ b/lib/modules/reading_diary/repository/reading_diary_repository.g.dart
@@ -235,6 +235,47 @@ class _ReadingDiaryRepository implements ReadingDiaryRepository {
   }
 
   @override
+  Future<ResponseForm<CursorPageResponse<DiaryResponse>>>
+      getReadingDiariesMembersFollowingPersonalizedFeed({
+    int? cursor,
+    int? size,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'cursor': cursor, r'size': size};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options =
+        _setStreamType<ResponseForm<CursorPageResponse<DiaryResponse>>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/reading-diaries/following/personalized-feed',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(
+            baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+          ),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ResponseForm<CursorPageResponse<DiaryResponse>> _value;
+    try {
+      _value = ResponseForm<CursorPageResponse<DiaryResponse>>.fromJson(
+        _result.data!,
+        (json) => CursorPageResponse<DiaryResponse>.fromJson(
+          json as Map<String, dynamic>,
+          (json) => DiaryResponse.fromJson(json as Map<String, dynamic>),
+        ),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
   Future<ResponseForm<CursorPageResponse<DiaryResponse>>> getBookDiaries(
     int bookId, {
     int? cursorId,


### PR DESCRIPTION
Fixes #166

<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. 예: Fixes #123 -->

---

**변경사항**
  - BookLogState에 개인화 피드용 페이지네이션 필드 추가 - personalizedFeedHasNext, personalizedFeedNextCursor
  - 기존 hasNext, nextCursor를 feedHasNext, feedNextCursor로 변경
  - refreshContentState()에서 팔로잉 피드 종료 시 개인화 피드 자동 로드
  - getReadingDiariesMembersFollowingPersonalizedFeed API 추가

<!-- 주요 변경사항을 간단히 설명해주세요. -->

---

**스크린샷**

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/6a965469-6a5f-4792-a1dd-abba3583bdd2" /> | <video src="https://github.com/user-attachments/assets/f9ed3a11-494a-48d7-9a01-677924592e6d" /> |

<!-- 변경 전/후 스크린샷을 첨부해주세요. 필요시 이미지를 드래그&드롭 하세요. -->