### PR TITLE
#194 #196 리딩챌린지 UI 개선

### DIFF
--- a/lib/common/components/base_screen.dart
+++ b/lib/common/components/base_screen.dart
@@ -298,6 +298,7 @@ abstract class BaseScreenState<T extends BaseScreen> extends ConsumerState<T>
         body: _buildBodyWithRefresh(context),
         // bottomNavigationBar: _buildBottomNavigationBar(context),
         floatingActionButton: buildFloatingActionButton(context),
+        floatingActionButtonAnimator: FloatingActionButtonAnimator.noAnimation,
         drawer: buildDrawer(context),
       ),
     );

--- a/lib/modules/reading_challenge/model/create_challenge_response.dart
+++ b/lib/modules/reading_challenge/model/create_challenge_response.dart
@@ -4,6 +4,7 @@ part 'create_challenge_response.freezed.dart';
 part 'create_challenge_response.g.dart';
 
 enum QuizGenerationStatus {
+  PENDING,
   PROCESSING,
   ALREADY_EXISTS,
 }
@@ -12,7 +13,7 @@ enum QuizGenerationStatus {
 abstract class CreateChallengeResponse with _$CreateChallengeResponse {
   const factory CreateChallengeResponse({
     @Default(-1) int challengeId,
-    @Default(QuizGenerationStatus.PROCESSING)
+    @Default(QuizGenerationStatus.PENDING)
     QuizGenerationStatus quizGenerationStatus,
     @Default(false) bool alreadyExists,
     @Default(false) bool hasChapter,

--- a/lib/modules/reading_challenge/model/create_challenge_response.g.dart
+++ b/lib/modules/reading_challenge/model/create_challenge_response.g.dart
@@ -28,6 +28,7 @@ Map<String, dynamic> _$CreateChallengeResponseToJson(
     };
 
 const _$QuizGenerationStatusEnumMap = {
+  QuizGenerationStatus.PENDING: 'PENDING',
   QuizGenerationStatus.PROCESSING: 'PROCESSING',
   QuizGenerationStatus.ALREADY_EXISTS: 'ALREADY_EXISTS',
 };

--- a/lib/modules/reading_data/view/screens/reading_data_detail_screen.dart
+++ b/lib/modules/reading_data/view/screens/reading_data_detail_screen.dart
@@ -3,7 +3,6 @@ import 'package:bookstar/common/components/custom_list_view.dart';
 import 'package:bookstar/common/theme/style/app_texts.dart';
 import 'package:bookstar/gen/assets.gen.dart';
 import 'package:bookstar/gen/colors.gen.dart';
-import 'package:bookstar/modules/reading_data/model/ranking_weekly_response.dart';
 import 'package:bookstar/modules/reading_data/view_model/reading_data_view_model.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
## Summary
- #194: 리딩챌린지에 새로운 책 추가 시 NEW 텍스트 표시 기능 추가
- #196: FloatingActionButton 애니메이션 무효화

## 주요 변경사항

### #194 새로운 책 추가 시 NEW 텍스트 표시
- ReadingChallengeScreen에 `_newIndex` 상태 변수 추가
- 새로 추가된 책의 이미지 좌측 상단에 NEW 배지 표시
- NEW 배지 스타일: 빨간색 배경(ColorName.p1), 흰색 텍스트
- 스크롤 대상 인덱스를 NEW 인덱스로도 설정

### #196 FloatingActionButton 애니메이션 무효화
- BaseScreen의 floatingActionButtonAnimator를 주석 처리하여 애니메이션 제거

### 기타 개선사항
- ReadingChallengeScreen UI 조정
  - FloatingActionButton 너비를 화면 너비의 90%로 설정
  - 타겟 아이템 하단 여백 60 → 80으로 증가
- QuizGenerationStatus enum 확장
  - PENDING 상태 추가
  - 기본값을 PROCESSING에서 PENDING으로 변경
- ReadingDataDetailScreen 코드 정리
  - 미사용 import 제거


https://github.com/user-attachments/assets/4fd284cd-a6a4-4117-806c-366be5a25e9b



## Test plan
- [ ] 리딩챌린지 화면에서 새로운 책 추가 시 NEW 배지가 표시되는지 확인
- [ ] NEW 배지 스타일 및 위치 확인 (책 이미지 좌측 상단)
- [ ] FloatingActionButton 애니메이션이 제거되었는지 확인
- [ ] FloatingActionButton UI가 화면 너비의 90%로 정상 표시되는지 확인
- [ ] 챌린지 시작 플로우가 정상 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)