### PR TITLE
#195 리딩챌린지 퀴즈 준비 중 이후, 준비 완료되면 선택 가능하도록 변경

### DIFF
--- a/lib/modules/reading_challenge/model/create_challenge_response.freezed.dart
+++ b/lib/modules/reading_challenge/model/create_challenge_response.freezed.dart
@@ -282,7 +282,7 @@ extension CreateChallengeResponsePatterns on CreateChallengeResponse {
 class _CreateChallengeResponse implements CreateChallengeResponse {
   const _CreateChallengeResponse(
       {this.challengeId = -1,
-      this.quizGenerationStatus = QuizGenerationStatus.PROCESSING,
+      this.quizGenerationStatus = QuizGenerationStatus.PENDING,
       this.alreadyExists = false,
       this.hasChapter = false});
   factory _CreateChallengeResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/modules/reading_challenge/model/create_challenge_response.g.dart
+++ b/lib/modules/reading_challenge/model/create_challenge_response.g.dart
@@ -12,7 +12,7 @@ _CreateChallengeResponse _$CreateChallengeResponseFromJson(
       challengeId: (json['challengeId'] as num?)?.toInt() ?? -1,
       quizGenerationStatus: $enumDecodeNullable(
               _$QuizGenerationStatusEnumMap, json['quizGenerationStatus']) ??
-          QuizGenerationStatus.PROCESSING,
+          QuizGenerationStatus.PENDING,
       alreadyExists: json['alreadyExists'] as bool? ?? false,
       hasChapter: json['hasChapter'] as bool? ?? false,
     );

--- a/lib/modules/reading_challenge/view/screens/reading_challenge_detail_screen.dart
+++ b/lib/modules/reading_challenge/view/screens/reading_challenge_detail_screen.dart
@@ -163,7 +163,7 @@ class _ReadingChallengeDetailScreenState
                             (user is AuthSuccess) ? user.memberId : 0;
                         ref.invalidate(getChallengesByMemberViewModelProvider(
                             memberId: memberId));
-                        await notifier.fetchChallenges();
+                        await notifier.initState();
                         if (context.mounted) {
                           await _showDeleteSuccessDialog(context);
                         }

--- a/lib/modules/reading_challenge/view_model/current_challenge_view_model.dart
+++ b/lib/modules/reading_challenge/view_model/current_challenge_view_model.dart
@@ -78,16 +78,13 @@ class CurrentChallengeViewModel extends _$CurrentChallengeViewModel {
       ref.invalidate(
           getChallengesByMemberViewModelProvider(memberId: memberId));
       // 완독한 챌린지 목록도 다시 가져오기
-      final notifier =
-          ref.read(ongoingChallengeViewModelProvider.notifier);
-      await notifier.fetchChallenges();
+      final notifier = ref.read(ongoingChallengeViewModelProvider.notifier);
+      await notifier.initState();
       return res.data.progressId;
     } catch (e) {
       print('Failed to create challenge: $e');
       rethrow;
     }
-
-    
   }
 
   Future<int> updateChallengeProgress(WidgetRef ref) async {
@@ -116,9 +113,8 @@ class CurrentChallengeViewModel extends _$CurrentChallengeViewModel {
       ref.invalidate(
           getChallengesByMemberViewModelProvider(memberId: memberId));
       // 완독한 챌린지 목록도 다시 가져오기
-      final notifier =
-          ref.read(ongoingChallengeViewModelProvider.notifier);
-      await notifier.fetchChallenges();
+      final notifier = ref.read(ongoingChallengeViewModelProvider.notifier);
+      await notifier.initState();
       return res.data.progressId;
     } catch (e) {
       debugPrint('Failed to update challenge progress: $e');

--- a/lib/modules/reading_challenge/view_model/ongoing_challenge_view_model.dart
+++ b/lib/modules/reading_challenge/view_model/ongoing_challenge_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:bookstar/common/models/response_form.dart';
 import 'package:bookstar/modules/reading_challenge/model/challenge_response.dart';
 import 'package:bookstar/modules/reading_challenge/repository/reading_challenge_repository.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -9,7 +10,7 @@ part 'ongoing_challenge_view_model.g.dart';
 @freezed
 abstract class OngoingChallengeScreenState with _$OngoingChallengeScreenState {
   const factory OngoingChallengeScreenState({
-    @Default(AsyncData([])) AsyncValue<List<ChallengeResponse>> challenges,
+    @Default([]) List<ChallengeResponse> challenges,
     @Default(false) bool isSelectionMode,
     @Default({}) Set<int> selectedChallengeIds,
   }) = _OngoingChallengeScreenState;
@@ -17,64 +18,95 @@ abstract class OngoingChallengeScreenState with _$OngoingChallengeScreenState {
 
 @riverpod
 class OngoingChallengeViewModel extends _$OngoingChallengeViewModel {
+  late ReadingChallengeRepository _readingChallengeRepository;
+
   @override
-  OngoingChallengeScreenState build() {
-    // `build`가 완료된 직후에 `_fetchChallenges`를 실행하도록 변경
-    Future.microtask(fetchChallenges);
-    return const OngoingChallengeScreenState();
+  FutureOr<OngoingChallengeScreenState> build() async {
+    _readingChallengeRepository = ref.read(readingChallengeRepositoryProvider);
+    return await initState();
   }
 
-  Future<void> fetchChallenges() async {
-    // state = state.copyWith(challenges: const AsyncLoading());
-    final repo = ref.read(readingChallengeRepositoryProvider);
-
-    final challenges = await AsyncValue.guard(() async {
-      final res = await repo.getOngoingChallenges();
-      return res.data;
-    });
-
-    state = state.copyWith(challenges: challenges);
+  Future<OngoingChallengeScreenState> initState() async {
+    final prev = state.value ?? OngoingChallengeScreenState();
+    final response = await _readingChallengeRepository.getOngoingChallenges();
+    state = AsyncValue.data(prev.copyWith(challenges: response.data));
+    return state.value ?? OngoingChallengeScreenState();
   }
 
   void toggleSelectionMode() {
-    final newMode = !state.isSelectionMode;
-    state = state.copyWith(
+    final prev = state.value ?? OngoingChallengeScreenState();
+
+    final newMode = !prev.isSelectionMode;
+    state = AsyncValue.data(prev.copyWith(
       isSelectionMode: newMode,
       // 선택 모드 해제 시 선택 목록 초기화
-      selectedChallengeIds: newMode ? state.selectedChallengeIds : {},
-    );
+      selectedChallengeIds: newMode ? prev.selectedChallengeIds : {},
+    ));
   }
 
   void toggleChallengeSelection(int challengeId) {
-    final newSelection = Set<int>.from(state.selectedChallengeIds);
+    final prev = state.value ?? OngoingChallengeScreenState();
+    final newSelection = Set<int>.from(prev.selectedChallengeIds);
     if (newSelection.contains(challengeId)) {
       newSelection.remove(challengeId);
     } else {
       newSelection.add(challengeId);
     }
-    state = state.copyWith(selectedChallengeIds: newSelection);
+    state = AsyncValue.data(prev.copyWith(selectedChallengeIds: newSelection));
   }
 
   Future<void> deleteSelectedChallenges() async {
-    final repo = ref.read(readingChallengeRepositoryProvider);
-    final idsToDelete = List<int>.from(state.selectedChallengeIds);
+    final prev = state.value ?? OngoingChallengeScreenState();
+    final idsToDelete = List<int>.from(prev.selectedChallengeIds);
 
-    // TODO: 로딩 상태 처리
-    await Future.wait(
-      idsToDelete.map(
-        (id) => repo.abandonChallenge(id), // DELETE 대신 POST /abandon 사용
-      ),
-    );
+    for (var id in idsToDelete) {
+      await _readingChallengeRepository.abandonChallenge(id);
+    }
 
-    state = state.copyWith(
+    state = AsyncValue.data(prev.copyWith(
       selectedChallengeIds: {},
       isSelectionMode: false,
-    );
+    ));
     ref.invalidateSelf();
   }
 
   Future<void> abandonChallenge(int challengeId) async {
-    final repo = ref.read(readingChallengeRepositoryProvider);
-    await repo.abandonChallenge(challengeId);
+    await _readingChallengeRepository.abandonChallenge(challengeId);
+  }
+
+  Future<void> pollingUntilHasQuiz(int challengeId) async {
+    pollStream<ResponseForm<List<ChallengeResponse>>>(
+      fetcher: () => _readingChallengeRepository.getOngoingChallenges(),
+      until: (response) => response.data.any((challenge) =>
+          challenge.challengeId == challengeId && challenge.hasQuiz),
+      onBreak: (response) {
+        final prev = state.value ?? OngoingChallengeScreenState();
+        state = AsyncValue.data(prev.copyWith(challenges: response.data));
+      },
+    ).listen((_) {});
+  }
+
+  // 3. Stream 기반 폴링
+  Stream<T> pollStream<T>({
+    required Future<T> Function() fetcher,
+    required bool Function(T) until,
+    required Function(T) onBreak,
+    Duration interval = const Duration(seconds: 3),
+  }) async* {
+    while (true) {
+      try {
+        final data = await fetcher();
+        yield data;
+
+        if (until(data)) {
+          onBreak(data);
+          break;
+        }
+      } catch (e) {
+        yield* Stream.error(e);
+      }
+
+      await Future.delayed(interval);
+    }
   }
 }

--- a/lib/modules/reading_challenge/view_model/ongoing_challenge_view_model.freezed.dart
+++ b/lib/modules/reading_challenge/view_model/ongoing_challenge_view_model.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$OngoingChallengeScreenState {
-  AsyncValue<List<ChallengeResponse>> get challenges;
+  List<ChallengeResponse> get challenges;
   bool get isSelectionMode;
   Set<int> get selectedChallengeIds;
 
@@ -32,8 +32,8 @@ mixin _$OngoingChallengeScreenState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is OngoingChallengeScreenState &&
-            (identical(other.challenges, challenges) ||
-                other.challenges == challenges) &&
+            const DeepCollectionEquality()
+                .equals(other.challenges, challenges) &&
             (identical(other.isSelectionMode, isSelectionMode) ||
                 other.isSelectionMode == isSelectionMode) &&
             const DeepCollectionEquality()
@@ -41,7 +41,10 @@ mixin _$OngoingChallengeScreenState {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, challenges, isSelectionMode,
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(challenges),
+      isSelectionMode,
       const DeepCollectionEquality().hash(selectedChallengeIds));
 
   @override
@@ -58,7 +61,7 @@ abstract mixin class $OngoingChallengeScreenStateCopyWith<$Res> {
       _$OngoingChallengeScreenStateCopyWithImpl;
   @useResult
   $Res call(
-      {AsyncValue<List<ChallengeResponse>> challenges,
+      {List<ChallengeResponse> challenges,
       bool isSelectionMode,
       Set<int> selectedChallengeIds});
 }
@@ -84,7 +87,7 @@ class _$OngoingChallengeScreenStateCopyWithImpl<$Res>
       challenges: null == challenges
           ? _self.challenges
           : challenges // ignore: cast_nullable_to_non_nullable
-              as AsyncValue<List<ChallengeResponse>>,
+              as List<ChallengeResponse>,
       isSelectionMode: null == isSelectionMode
           ? _self.isSelectionMode
           : isSelectionMode // ignore: cast_nullable_to_non_nullable
@@ -190,8 +193,8 @@ extension OngoingChallengeScreenStatePatterns on OngoingChallengeScreenState {
 
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
-    TResult Function(AsyncValue<List<ChallengeResponse>> challenges,
-            bool isSelectionMode, Set<int> selectedChallengeIds)?
+    TResult Function(List<ChallengeResponse> challenges, bool isSelectionMode,
+            Set<int> selectedChallengeIds)?
         $default, {
     required TResult orElse(),
   }) {
@@ -220,8 +223,8 @@ extension OngoingChallengeScreenStatePatterns on OngoingChallengeScreenState {
 
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(AsyncValue<List<ChallengeResponse>> challenges,
-            bool isSelectionMode, Set<int> selectedChallengeIds)
+    TResult Function(List<ChallengeResponse> challenges, bool isSelectionMode,
+            Set<int> selectedChallengeIds)
         $default,
   ) {
     final _that = this;
@@ -248,8 +251,8 @@ extension OngoingChallengeScreenStatePatterns on OngoingChallengeScreenState {
 
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(AsyncValue<List<ChallengeResponse>> challenges,
-            bool isSelectionMode, Set<int> selectedChallengeIds)?
+    TResult? Function(List<ChallengeResponse> challenges, bool isSelectionMode,
+            Set<int> selectedChallengeIds)?
         $default,
   ) {
     final _that = this;
@@ -267,14 +270,21 @@ extension OngoingChallengeScreenStatePatterns on OngoingChallengeScreenState {
 
 class _OngoingChallengeScreenState implements OngoingChallengeScreenState {
   const _OngoingChallengeScreenState(
-      {this.challenges = const AsyncData([]),
+      {final List<ChallengeResponse> challenges = const [],
       this.isSelectionMode = false,
       final Set<int> selectedChallengeIds = const {}})
-      : _selectedChallengeIds = selectedChallengeIds;
+      : _challenges = challenges,
+        _selectedChallengeIds = selectedChallengeIds;
 
+  final List<ChallengeResponse> _challenges;
   @override
   @JsonKey()
-  final AsyncValue<List<ChallengeResponse>> challenges;
+  List<ChallengeResponse> get challenges {
+    if (_challenges is EqualUnmodifiableListView) return _challenges;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_challenges);
+  }
+
   @override
   @JsonKey()
   final bool isSelectionMode;
@@ -302,8 +312,8 @@ class _OngoingChallengeScreenState implements OngoingChallengeScreenState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _OngoingChallengeScreenState &&
-            (identical(other.challenges, challenges) ||
-                other.challenges == challenges) &&
+            const DeepCollectionEquality()
+                .equals(other._challenges, _challenges) &&
             (identical(other.isSelectionMode, isSelectionMode) ||
                 other.isSelectionMode == isSelectionMode) &&
             const DeepCollectionEquality()
@@ -311,7 +321,10 @@ class _OngoingChallengeScreenState implements OngoingChallengeScreenState {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, challenges, isSelectionMode,
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_challenges),
+      isSelectionMode,
       const DeepCollectionEquality().hash(_selectedChallengeIds));
 
   @override
@@ -330,7 +343,7 @@ abstract mixin class _$OngoingChallengeScreenStateCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {AsyncValue<List<ChallengeResponse>> challenges,
+      {List<ChallengeResponse> challenges,
       bool isSelectionMode,
       Set<int> selectedChallengeIds});
 }
@@ -354,9 +367,9 @@ class __$OngoingChallengeScreenStateCopyWithImpl<$Res>
   }) {
     return _then(_OngoingChallengeScreenState(
       challenges: null == challenges
-          ? _self.challenges
+          ? _self._challenges
           : challenges // ignore: cast_nullable_to_non_nullable
-              as AsyncValue<List<ChallengeResponse>>,
+              as List<ChallengeResponse>,
       isSelectionMode: null == isSelectionMode
           ? _self.isSelectionMode
           : isSelectionMode // ignore: cast_nullable_to_non_nullable

--- a/lib/modules/reading_challenge/view_model/ongoing_challenge_view_model.g.dart
+++ b/lib/modules/reading_challenge/view_model/ongoing_challenge_view_model.g.dart
@@ -7,11 +7,11 @@ part of 'ongoing_challenge_view_model.dart';
 // **************************************************************************
 
 String _$ongoingChallengeViewModelHash() =>
-    r'02cf88c57e41c7b5a01e47d8170d60455725ebb3';
+    r'371e760cdfd233ac601420be71752ae879abd5b4';
 
 /// See also [OngoingChallengeViewModel].
 @ProviderFor(OngoingChallengeViewModel)
-final ongoingChallengeViewModelProvider = AutoDisposeNotifierProvider<
+final ongoingChallengeViewModelProvider = AutoDisposeAsyncNotifierProvider<
     OngoingChallengeViewModel, OngoingChallengeScreenState>.internal(
   OngoingChallengeViewModel.new,
   name: r'ongoingChallengeViewModelProvider',
@@ -23,6 +23,6 @@ final ongoingChallengeViewModelProvider = AutoDisposeNotifierProvider<
 );
 
 typedef _$OngoingChallengeViewModel
-    = AutoDisposeNotifier<OngoingChallengeScreenState>;
+    = AutoDisposeAsyncNotifier<OngoingChallengeScreenState>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
Fixes #195

## Summary
- 리딩챌린지 메인 화면에서 퀴즈 준비 중인 챌린지를 선택하면, 퀴즈 준비가 완료될 때까지 폴링하고 완료 시 "리딩 챌린지 시작하기" 버튼 활성화
- OngoingChallengeViewModel을 AsyncNotifier로 리팩토링하고 폴링 기능 추가
- 상태 구조 단순화 및 메서드명 통일

## 주요 변경사항
### 1. OngoingChallengeViewModel 리팩토링
- `AutoDisposeNotifier` → `AutoDisposeAsyncNotifier`로 변경
- State 구조 단순화: `AsyncValue<List<ChallengeResponse>>` → `List<ChallengeResponse>`
- `fetchChallenges()` → `initState()`로 메서드명 변경
- `pollingUntilHasQuiz()` 메서드 추가: 퀴즈 준비 완료 시까지 3초마다 폴링
- `pollStream()` 메서드 추가: Stream 기반 폴링 유틸리티 함수

### 2. ReadingChallengeScreen 업데이트
- 챌린지 ID 전달 시 해당 챌린지로 자동 스크롤
- `hasQuiz`가 false인 경우 자동으로 폴링 시작
- 퀴즈 준비 완료 시 "리딩 챌린지 시작하기" 버튼 활성화
- FloatingActionButton에서 실시간으로 hasQuiz 상태 확인
- 상태 접근 방식 변경 (`state.challenges.value` → `state.value.challenges`)

### 3. CreateChallengeResponse 기본값 변경
- `quizGenerationStatus` 기본값: `PROCESSING` → `PENDING`

### 4. 전체적으로 메서드 호출 통일
- `fetchChallenges()` → `initState()` 호출로 통일
  - ReadingChallengeDetailScreen
  - CurrentChallengeViewModel

## 기술적 구현
- Stream 기반 폴링으로 퀴즈 생성 완료 감지
- `pollStream()`: 제네릭 폴링 함수로 재사용 가능하게 설계
- `until` 조건: `challengeId`와 `hasQuiz`를 모두 확인하여 정확한 타이밍에 폴링 중단
- `onBreak` 콜백으로 폴링 완료 시 state 자동 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)