### PR TITLE
#197 #198 #200 책로그 UI 개선

### DIFF
--- a/lib/modules/book_log/view/screens/book_log_create_screen.dart
+++ b/lib/modules/book_log/view/screens/book_log_create_screen.dart
@@ -98,6 +98,7 @@ class _BookLogCreateScreenState extends BaseScreenState<BookLogCreateScreen> {
   @override
   Widget buildBody(BuildContext context) {
     return ReadingDiaryEditForm(
+        isEdit: false,
         textController: _textController,
         images: _images,
         currentImageIndex: _currentImageIndex,

--- a/lib/modules/book_log/view/screens/book_log_update_screen.dart
+++ b/lib/modules/book_log/view/screens/book_log_update_screen.dart
@@ -110,6 +110,7 @@ class _BookLogUpdateScreenState extends BaseScreenState<BookLogUpdateScreen> {
   @override
   Widget buildBody(BuildContext context) {
     return ReadingDiaryEditForm(
+        isEdit: true,
         textController: _textController,
         images: _images,
         currentImageIndex: _currentImageIndex,

--- a/lib/modules/book_log/view/widgets/select_image_dialog.dart
+++ b/lib/modules/book_log/view/widgets/select_image_dialog.dart
@@ -141,16 +141,13 @@ class _SelectImageDialogState extends BaseScreenState<SelectImageDialog> {
   PreferredSizeWidget? buildAppBar(BuildContext context) {
     return AppBar(
       title: const Text('책로그'),
-      leading: IconButton(
-        icon: const BackButton(),
-        onPressed: () => Navigator.of(context).pop(),
-      ),
+      automaticallyImplyLeading: false,
       actions: [
         GestureDetector(
           onTap: () => Navigator.of(context).pop(_selectedImages),
           child: Text("완료", style: AppTexts.b8.copyWith(color: ColorName.g1)),
         ),
-        SizedBox(width: 8),
+        SizedBox(width: 16),
       ],
     );
   }
@@ -206,6 +203,7 @@ class _SelectImageDialogState extends BaseScreenState<SelectImageDialog> {
               SizedBox(height: 12),
               _albums.isNotEmpty
                   ? PopupMenuButton<int>(
+                      color: ColorName.dim3.withValues(alpha: 0.7),
                       offset: Offset(0, 25),
                       child: Row(
                         mainAxisSize: MainAxisSize.min,
@@ -227,8 +225,8 @@ class _SelectImageDialogState extends BaseScreenState<SelectImageDialog> {
                         return _albums.asMap().entries.map((entry) {
                           int index = entry.key;
                           AssetPathEntity album = entry.value;
-
                           return PopupMenuItem<int>(
+                            height: 32,
                             value: index,
                             child: Text(album.name),
                           );

--- a/lib/modules/reading_diary/view/widgets/reading_diary_edit_form.dart
+++ b/lib/modules/reading_diary/view/widgets/reading_diary_edit_form.dart
@@ -34,6 +34,7 @@ class GalleryImage extends ImageItem {
 class ReadingDiaryEditForm extends BaseScreen {
   const ReadingDiaryEditForm({
     super.key,
+    required this.isEdit,
     required this.textController,
     required this.images,
     required this.currentImageIndex,
@@ -52,6 +53,7 @@ class ReadingDiaryEditForm extends BaseScreen {
     required this.onUpdateSelectedBookId,
   });
 
+  final bool isEdit;
   final TextEditingController textController;
   final List<ImageItem> images;
   final int currentImageIndex;
@@ -180,7 +182,11 @@ class _ReadingDiaryEditFormState extends BaseScreenState<ReadingDiaryEditForm> {
             _buildRegisterBookButton(
               selectedBookId: widget.selectedBookId,
               bookOverview: state.value,
-              onPressed: _openSelectBookDialog,
+              onPressed: () {
+                if (!widget.isEdit) {
+                  _openSelectBookDialog();
+                }
+              },
             ),
             SizedBox(height: 12),
             _buildPrivacyButton(
@@ -189,16 +195,16 @@ class _ReadingDiaryEditFormState extends BaseScreenState<ReadingDiaryEditForm> {
                 widget.onUpdatePrivacy(!widget.privacy);
               },
             ),
-            if (isNotEmptyText &&
-                isOver10lines &&
-                widget.selectedBookId != null)
-              _buildSubmitButton(
-                  disabled: widget.disabledSave,
-                  onSave: () async {
-                    widget.onUpdateDisabledSave(true);
-                    await widget.onSave();
-                    widget.onUpdateDisabledSave(false);
-                  }),
+            _buildSubmitButton(
+                disabled: widget.disabledSave ||
+                    !isNotEmptyText ||
+                    !isOver10lines ||
+                    widget.selectedBookId == null,
+                onSave: () async {
+                  widget.onUpdateDisabledSave(true);
+                  await widget.onSave();
+                  widget.onUpdateDisabledSave(false);
+                }),
             SizedBox(
               height: 16,
             )
@@ -272,7 +278,7 @@ class _ReadingDiaryEditFormState extends BaseScreenState<ReadingDiaryEditForm> {
                               Container(),
                             Positioned(
                                 top: 16,
-                                right: 16,
+                                right: 0,
                                 child: Container(
                                   decoration: BoxDecoration(
                                       borderRadius: BorderRadius.circular(100),


### PR DESCRIPTION
Fixes #197
Fixes #198
Fixes #200

## Summary
- #197: 갤러리 파일 선택 드롭다운 메뉴의 배경색 및 불투명도 수정
  - PopupMenuButton에 dim3 배경색과 0.7 투명도 적용
  - PopupMenuItem 높이를 32로 설정
- #198: 갤러리 파일 선택 완료 버튼 마진 수정
  - AppBar 완료 버튼 우측 마진을 8에서 16으로 증가
  - AppBar leading 버튼 제거
- #200: 책로그 작성 시 등록하기 버튼이 항상 표시되도록 변경
  - ReadingDiaryEditForm에 isEdit 파라미터 추가하여 작성/수정 모드 구분
  - 등록하기 버튼 조건부 렌더링을 disabled 속성으로 변경
  - 수정 모드에서는 책 선택 버튼 비활성화

## Test plan
- [ ] 책로그 작성 화면에서 갤러리 파일 선택 시 드롭다운 메뉴의 배경색과 불투명도 확인
- [ ] 갤러리 완료 버튼의 우측 마진이 적절하게 적용되었는지 확인
- [ ] 책로그 작성 화면에서 등록하기 버튼이 항상 표시되는지 확인
- [ ] 조건 미충족 시 등록하기 버튼이 비활성화 상태로 표시되는지 확인
- [ ] 책로그 수정 화면에서 책 선택 버튼이 비활성화되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)