### PR TITLE
#204 #205 마이피드, 책로그 UI 개선

### DIFF
--- a/lib/modules/book_log/view/widgets/book_log_thumbnail_grid.dart
+++ b/lib/modules/book_log/view/widgets/book_log_thumbnail_grid.dart
@@ -1,3 +1,5 @@
+import 'package:bookstar/common/theme/style/app_texts.dart';
+import 'package:bookstar/gen/assets.gen.dart';
 import 'package:bookstar/modules/reading_diary/model/diary_thumbnail_response.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -38,16 +40,33 @@ class _BookLogThumbnailGridState extends ConsumerState<BookLogThumbnailGrid> {
         onTap: (index) {
           widget.onClickThumbnail(index);
         },
-        emptyWidget: const Center(
-          child: Text(
-            '아직 책로그가 없습니다.',
-            style: TextStyle(
-              color: ColorName.g7,
-              fontSize: 14,
-              fontWeight: FontWeight.w400,
+        emptyWidget: LayoutBuilder(builder: (context, constraints) {
+          return SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minHeight: constraints.maxHeight,
+              ),
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Assets.icons.icBooktalkSearchCharacter.svg(
+                      width: 110,
+                      height: 110,
+                    ),
+                    SizedBox(height: 18),
+                    Text(
+                      "아직 책로그가 없습니다.",
+                      textAlign: TextAlign.center,
+                      style: AppTexts.b7.copyWith(color: ColorName.w1),
+                    ),
+                  ],
+                ),
+              ),
             ),
-          ),
-        ),
+          );
+        }),
       ),
     );
   }

--- a/lib/modules/book_log/view/widgets/feed_card.dart
+++ b/lib/modules/book_log/view/widgets/feed_card.dart
@@ -64,7 +64,11 @@ class _FeedCardState extends ConsumerState<FeedCard> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.only(
+            top: 16,
+            bottom: 16,
+            left: 16,
+          ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [

--- a/lib/modules/book_pick/view/screens/book_pick_screen.dart
+++ b/lib/modules/book_pick/view/screens/book_pick_screen.dart
@@ -33,6 +33,11 @@ class _BookPickScreenState extends BaseScreenState<BookPickScreen> {
   int _currentIndex = 0;
 
   @override
+  int getListTotalItemCount() =>
+      ref.watch(bookPickViewModelProvider).value?.likeBook.likeBooks.length ??
+      0;
+
+  @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/modules/my_page/view/screens/liked_diaries_screen.dart
+++ b/lib/modules/my_page/view/screens/liked_diaries_screen.dart
@@ -35,7 +35,7 @@ class _LikedDiariesScreenState extends BaseScreenState<LikedDiariesScreen> {
   @override
   PreferredSizeWidget? buildAppBar(BuildContext context) {
     return AppBar(
-      title: const Text('좋아요 누른 다이어리'),
+      title: const Text('좋아요 누른 책로그'),
       leading: IconButton(
         icon: const BackButton(),
         onPressed: () => Navigator.of(context).pop(),

--- a/lib/modules/my_page/view/screens/my_page_screen.dart
+++ b/lib/modules/my_page/view/screens/my_page_screen.dart
@@ -57,13 +57,13 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
               Text('활동 내역', style: AppTexts.b5.copyWith(color: ColorName.w1)),
               const SizedBox(height: 8),
               CustomTextButton(
-                label: '좋아요 누른 다이어리',
+                label: '좋아요 누른 책로그',
                 onTap: () {
                   context.go('/my-feed/my-page/liked-diaries');
                 },
               ),
               CustomTextButton(
-                label: '스크랩한 다이어리',
+                label: '스크랩한 책로그',
                 onTap: () {
                   context.go('/my-feed/my-page/scrapped-diaries');
                 },

--- a/lib/modules/my_page/view/screens/scrapped_diaries_screen.dart
+++ b/lib/modules/my_page/view/screens/scrapped_diaries_screen.dart
@@ -36,7 +36,7 @@ class _ScrappedDiariesScreenState
   @override
   PreferredSizeWidget? buildAppBar(BuildContext context) {
     return AppBar(
-      title: const Text('스크랩한 다이어리'),
+      title: const Text('스크랩한 책로그'),
       leading: IconButton(
         icon: const BackButton(),
         onPressed: () => Navigator.of(context).pop(),

--- a/lib/modules/reading_diary/view/screens/liked_diary_feed_screen.dart
+++ b/lib/modules/reading_diary/view/screens/liked_diary_feed_screen.dart
@@ -46,7 +46,7 @@ class _LikedDiaryFeedScreenState extends BaseScreenState<LikedDiaryFeedScreen> {
   @override
   PreferredSizeWidget? buildAppBar(BuildContext context) {
     return AppBar(
-      title: const Text('좋아요 누른 다이어리'),
+      title: const Text('좋아요 누른 책로그'),
       leading: IconButton(
         icon: const BackButton(),
         onPressed: () => Navigator.of(context).pop(),

--- a/lib/modules/reading_diary/view/screens/scrapped_diary_feed_screen.dart
+++ b/lib/modules/reading_diary/view/screens/scrapped_diary_feed_screen.dart
@@ -28,38 +28,40 @@ class _ScrappedDiaryFeedScreenState
   @override
   bool enableRefreshIndicator() => true;
 
-    @override
+  @override
   int getListTotalItemCount() =>
       ref.watch(scrappedDiaryViewModelProvider).value?.feeds.length ?? 0;
 
-    @override
+  @override
   Future<void> onRefresh() async {
-    final likedDiaryNotifier = ref.read(scrappedDiaryViewModelProvider.notifier);
+    final likedDiaryNotifier =
+        ref.read(scrappedDiaryViewModelProvider.notifier);
     await likedDiaryNotifier.initState();
   }
 
   @override
   Future<void> onBottomReached() async {
-    final likedDiaryNotifier = ref.read(scrappedDiaryViewModelProvider.notifier);
+    final likedDiaryNotifier =
+        ref.read(scrappedDiaryViewModelProvider.notifier);
     await likedDiaryNotifier.refreshState();
   }
 
   @override
   PreferredSizeWidget? buildAppBar(BuildContext context) {
     return AppBar(
-        title: const Text('스크랩한 다이어리'),
-        leading: IconButton(
-          icon: const BackButton(),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      );
+      title: const Text('스크랩한 책로그'),
+      leading: IconButton(
+        icon: const BackButton(),
+        onPressed: () => Navigator.of(context).pop(),
+      ),
+    );
   }
-
 
   @override
   Widget buildBody(BuildContext context) {
     final scrappedDiaryAsync = ref.watch(scrappedDiaryViewModelProvider);
-    final scrappedDiaryNotifier = ref.read(scrappedDiaryViewModelProvider.notifier);
+    final scrappedDiaryNotifier =
+        ref.read(scrappedDiaryViewModelProvider.notifier);
     return scrappedDiaryAsync.when(
       data: (scrappedDiary) => BookLogFeedList(
         visibleMenu: false,


### PR DESCRIPTION
Fixes #204
Fixes #205

## Summary
- 책로그 empty 화면 개선
  - BookLogThumbnailGrid: 아이콘 추가 및 레이아웃 개선
  - 중앙 정렬된 empty 상태 UI 구현
- FeedCard 아이콘 마진 조정
  - right padding 제거하여 아이콘 정렬 개선
- 텍스트 수정: '다이어리' → '책로그'
  - LikedDiariesScreen, ScrappedDiariesScreen
  - MyPageScreen
  - LikedDiaryFeedScreen, ScrappedDiaryFeedScreen
- BookPickScreen에 getListTotalItemCount() 추가
- 코드 포맷팅 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)