### PR TITLE
#201 책로그: 나만보기 버튼을 토글 스위치로 변경

### DIFF
--- a/lib/common/components/custom_switch.dart
+++ b/lib/common/components/custom_switch.dart
@@ -1,0 +1,132 @@
+import 'package:bookstar/gen/colors.gen.dart';
+import 'package:flutter/material.dart';
+
+class CustomSwitch extends StatefulWidget {
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final Color activeColor;
+  final Color inactiveColor;
+  final Color activeThumbColor;
+  final Color inactiveThumbColor;
+  final double width;
+  final double height;
+  final double thumbSize;
+  final Duration animationDuration;
+
+  const CustomSwitch({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.activeColor = ColorName.p1,
+    this.inactiveColor = ColorName.w1,
+    this.activeThumbColor = ColorName.w1,
+    this.inactiveThumbColor = ColorName.g3,
+    this.width = 45.0,
+    this.height = 25.0,
+    this.thumbSize = 18.0,
+    this.animationDuration = const Duration(milliseconds: 200),
+  });
+
+  @override
+  State<CustomSwitch> createState() => _CustomSwitchState();
+}
+
+class _CustomSwitchState extends State<CustomSwitch>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _animationController;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(
+      vsync: this,
+      duration: widget.animationDuration,
+    );
+    _animation = CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    );
+
+    if (widget.value) {
+      _animationController.value = 1.0;
+    }
+  }
+
+  @override
+  void didUpdateWidget(CustomSwitch oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.value != oldWidget.value) {
+      if (widget.value) {
+        _animationController.forward();
+      } else {
+        _animationController.reverse();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        if (widget.onChanged != null) {
+          widget.onChanged!(!widget.value);
+        }
+      },
+      child: AnimatedBuilder(
+        animation: _animation,
+        builder: (context, child) {
+          return Container(
+            width: widget.width,
+            height: widget.height,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(widget.height / 2),
+              color: Color.lerp(
+                widget.inactiveColor,
+                widget.activeColor,
+                _animation.value,
+              ),
+            ),
+            child: Stack(
+              children: [
+                AnimatedPositioned(
+                  duration: widget.animationDuration,
+                  curve: Curves.easeInOut,
+                  left:
+                      _animation.value * (widget.width - widget.thumbSize - 4) +
+                          2,
+                  top: (widget.height - widget.thumbSize) / 2,
+                  child: Container(
+                    width: widget.thumbSize,
+                    height: widget.thumbSize,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Color.lerp(
+                        widget.inactiveThumbColor,
+                        widget.activeThumbColor,
+                        _animation.value,
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: ColorName.g3.withValues(alpha: 0.2),
+                          blurRadius: 4,
+                          offset: Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/modules/reading_diary/view/widgets/reading_diary_edit_form.dart
+++ b/lib/modules/reading_diary/view/widgets/reading_diary_edit_form.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:bookstar/common/components/base_screen.dart';
 import 'package:bookstar/common/components/button/cta_button_l1.dart';
+import 'package:bookstar/common/components/custom_switch.dart';
 import 'package:bookstar/common/models/image_request.dart';
 import 'package:bookstar/common/theme/style/app_texts.dart';
 import 'package:bookstar/gen/assets.gen.dart';
@@ -548,27 +549,11 @@ class _ReadingDiaryEditFormState extends BaseScreenState<ReadingDiaryEditForm> {
                   ],
                 ),
               ),
-              GestureDetector(
-                onTap: onPressed,
-                child: Container(
-                  width: 24,
-                  height: 24,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: privacy ? ColorName.w2 : ColorName.g1,
-                    border: Border.all(
-                      color: privacy ? ColorName.w2 : ColorName.w1,
-                      width: 2,
-                    ),
-                  ),
-                  child: privacy
-                      ? Padding(
-                          padding: const EdgeInsets.all(4.0),
-                          child: Assets.icons.icCheck.svg(),
-                        )
-                      : null,
-                ),
-              )
+              CustomSwitch(
+                  value: privacy,
+                  onChanged: (_) {
+                    onPressed();
+                  })
             ],
           ),
         ),


### PR DESCRIPTION
Fixes #201

## Summary
- 책로그 작성 시 나만보기 옵션을 기존 체크박스에서 토글 스위치로 변경
- 더 직관적이고 모던한 UI/UX 제공

## 주요 변경사항
- **CustomSwitch 컴포넌트 추가**
  - 커스텀 애니메이션 토글 스위치 구현
  - 활성/비활성 색상 커스터마이징 가능
  - 부드러운 애니메이션 효과 (200ms)
  - 그림자 효과가 있는 thumb 디자인
  
- **ReadingDiaryEditForm 수정**
  - 나만보기 체크박스를 CustomSwitch로 교체
  - 기존 GestureDetector 기반 원형 체크박스 제거

## 스크린샷
<!-- 필요 시 스크린샷 추가 -->
| Before | After |
|--------|-------|
| <img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/f3be485c-e003-45f4-aef1-f22f3867da50" /> | <img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/9fcb3cb4-7832-49c0-98e1-46977ddc8af2" /> |








🤖 Generated with [Claude Code](https://claude.com/claude-code)