### PR TITLE
#219 마이피드:프로필 편집 후, 새로고침 없이 데이터 갱신

### DIFF
--- a/lib/modules/profile/view/screens/profile_screen.dart
+++ b/lib/modules/profile/view/screens/profile_screen.dart
@@ -166,13 +166,9 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           const SnackBar(content: Text('프로필이 저장되었습니다.')),
         );
 
-        //
-        final userAsync = ref.watch(authViewModelProvider);
-        final user = userAsync.value;
-        final currentMemberId = (user is AuthSuccess) ? user.memberId : -1;
-        final bookLogNotifier =
-            ref.read(bookLogViewModelProvider(currentMemberId).notifier);
-        bookLogNotifier.initState(currentMemberId);
+        if (myMemberId != null) {
+          ref.read(bookLogViewModelProvider(myMemberId).notifier).initState(myMemberId);
+        }
         context.pop();
       }
     } catch (e) {


### PR DESCRIPTION
Fixes #219

## Summary
- 프로필 편집 후 새로고침 없이 북로그 데이터 자동 갱신

## Test plan
- [x] 프로필 편집 화면에서 프로필 정보 수정
- [x] 저장 버튼 클릭
- [x] 북로그 화면으로 돌아갔을 때 변경된 프로필 정보가 자동으로 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- 필요 시 스크린샷 추가 -->


https://github.com/user-attachments/assets/ec3d7bf9-a984-4a55-979e-326307b044ef



| Before | After |
|--------|-------|
|  |  |