### PR TITLE
#222 alreadyExists/hasChapter/hasQuiz 속성을 책 조회 API에 추가

### DIFF
--- a/lib/modules/book_pick/model/like_book_response.dart
+++ b/lib/modules/book_pick/model/like_book_response.dart
@@ -12,6 +12,9 @@ abstract class LikeBookResponse with _$LikeBookResponse {
     @Default('') String pubDate,
     @Default('') String author,
     @Default('') String publisher,
+    @Default(false) bool alreadyExists,
+    @Default(false) bool hasChapter,
+    @Default(false) bool hasQuiz,
   }) = _LikeBookResponse;
 
   factory LikeBookResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/modules/book_pick/model/like_book_response.freezed.dart
+++ b/lib/modules/book_pick/model/like_book_response.freezed.dart
@@ -20,6 +20,9 @@ mixin _$LikeBookResponse {
   String get pubDate;
   String get author;
   String get publisher;
+  bool get alreadyExists;
+  bool get hasChapter;
+  bool get hasQuiz;
 
   /// Create a copy of LikeBookResponse
   /// with the given fields replaced by the non-null parameter values.
@@ -44,17 +47,22 @@ mixin _$LikeBookResponse {
             (identical(other.pubDate, pubDate) || other.pubDate == pubDate) &&
             (identical(other.author, author) || other.author == author) &&
             (identical(other.publisher, publisher) ||
-                other.publisher == publisher));
+                other.publisher == publisher) &&
+            (identical(other.alreadyExists, alreadyExists) ||
+                other.alreadyExists == alreadyExists) &&
+            (identical(other.hasChapter, hasChapter) ||
+                other.hasChapter == hasChapter) &&
+            (identical(other.hasQuiz, hasQuiz) || other.hasQuiz == hasQuiz));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, bookId, title, bookCover, pubDate, author, publisher);
+  int get hashCode => Object.hash(runtimeType, bookId, title, bookCover,
+      pubDate, author, publisher, alreadyExists, hasChapter, hasQuiz);
 
   @override
   String toString() {
-    return 'LikeBookResponse(bookId: $bookId, title: $title, bookCover: $bookCover, pubDate: $pubDate, author: $author, publisher: $publisher)';
+    return 'LikeBookResponse(bookId: $bookId, title: $title, bookCover: $bookCover, pubDate: $pubDate, author: $author, publisher: $publisher, alreadyExists: $alreadyExists, hasChapter: $hasChapter, hasQuiz: $hasQuiz)';
   }
 }
 
@@ -70,7 +78,10 @@ abstract mixin class $LikeBookResponseCopyWith<$Res> {
       String bookCover,
       String pubDate,
       String author,
-      String publisher});
+      String publisher,
+      bool alreadyExists,
+      bool hasChapter,
+      bool hasQuiz});
 }
 
 /// @nodoc
@@ -92,6 +103,9 @@ class _$LikeBookResponseCopyWithImpl<$Res>
     Object? pubDate = null,
     Object? author = null,
     Object? publisher = null,
+    Object? alreadyExists = null,
+    Object? hasChapter = null,
+    Object? hasQuiz = null,
   }) {
     return _then(_self.copyWith(
       bookId: null == bookId
@@ -118,6 +132,18 @@ class _$LikeBookResponseCopyWithImpl<$Res>
           ? _self.publisher
           : publisher // ignore: cast_nullable_to_non_nullable
               as String,
+      alreadyExists: null == alreadyExists
+          ? _self.alreadyExists
+          : alreadyExists // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasChapter: null == hasChapter
+          ? _self.hasChapter
+          : hasChapter // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasQuiz: null == hasQuiz
+          ? _self.hasQuiz
+          : hasQuiz // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -215,16 +241,32 @@ extension LikeBookResponsePatterns on LikeBookResponse {
 
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
-    TResult Function(int bookId, String title, String bookCover, String pubDate,
-            String author, String publisher)?
+    TResult Function(
+            int bookId,
+            String title,
+            String bookCover,
+            String pubDate,
+            String author,
+            String publisher,
+            bool alreadyExists,
+            bool hasChapter,
+            bool hasQuiz)?
         $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
       case _LikeBookResponse() when $default != null:
-        return $default(_that.bookId, _that.title, _that.bookCover,
-            _that.pubDate, _that.author, _that.publisher);
+        return $default(
+            _that.bookId,
+            _that.title,
+            _that.bookCover,
+            _that.pubDate,
+            _that.author,
+            _that.publisher,
+            _that.alreadyExists,
+            _that.hasChapter,
+            _that.hasQuiz);
       case _:
         return orElse();
     }
@@ -245,15 +287,31 @@ extension LikeBookResponsePatterns on LikeBookResponse {
 
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(int bookId, String title, String bookCover, String pubDate,
-            String author, String publisher)
+    TResult Function(
+            int bookId,
+            String title,
+            String bookCover,
+            String pubDate,
+            String author,
+            String publisher,
+            bool alreadyExists,
+            bool hasChapter,
+            bool hasQuiz)
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _LikeBookResponse():
-        return $default(_that.bookId, _that.title, _that.bookCover,
-            _that.pubDate, _that.author, _that.publisher);
+        return $default(
+            _that.bookId,
+            _that.title,
+            _that.bookCover,
+            _that.pubDate,
+            _that.author,
+            _that.publisher,
+            _that.alreadyExists,
+            _that.hasChapter,
+            _that.hasQuiz);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -273,15 +331,31 @@ extension LikeBookResponsePatterns on LikeBookResponse {
 
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(int bookId, String title, String bookCover,
-            String pubDate, String author, String publisher)?
+    TResult? Function(
+            int bookId,
+            String title,
+            String bookCover,
+            String pubDate,
+            String author,
+            String publisher,
+            bool alreadyExists,
+            bool hasChapter,
+            bool hasQuiz)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _LikeBookResponse() when $default != null:
-        return $default(_that.bookId, _that.title, _that.bookCover,
-            _that.pubDate, _that.author, _that.publisher);
+        return $default(
+            _that.bookId,
+            _that.title,
+            _that.bookCover,
+            _that.pubDate,
+            _that.author,
+            _that.publisher,
+            _that.alreadyExists,
+            _that.hasChapter,
+            _that.hasQuiz);
       case _:
         return null;
     }
@@ -297,7 +371,10 @@ class _LikeBookResponse implements LikeBookResponse {
       this.bookCover = '',
       this.pubDate = '',
       this.author = '',
-      this.publisher = ''});
+      this.publisher = '',
+      this.alreadyExists = false,
+      this.hasChapter = false,
+      this.hasQuiz = false});
   factory _LikeBookResponse.fromJson(Map<String, dynamic> json) =>
       _$LikeBookResponseFromJson(json);
 
@@ -319,6 +396,15 @@ class _LikeBookResponse implements LikeBookResponse {
   @override
   @JsonKey()
   final String publisher;
+  @override
+  @JsonKey()
+  final bool alreadyExists;
+  @override
+  @JsonKey()
+  final bool hasChapter;
+  @override
+  @JsonKey()
+  final bool hasQuiz;
 
   /// Create a copy of LikeBookResponse
   /// with the given fields replaced by the non-null parameter values.
@@ -347,17 +433,22 @@ class _LikeBookResponse implements LikeBookResponse {
             (identical(other.pubDate, pubDate) || other.pubDate == pubDate) &&
             (identical(other.author, author) || other.author == author) &&
             (identical(other.publisher, publisher) ||
-                other.publisher == publisher));
+                other.publisher == publisher) &&
+            (identical(other.alreadyExists, alreadyExists) ||
+                other.alreadyExists == alreadyExists) &&
+            (identical(other.hasChapter, hasChapter) ||
+                other.hasChapter == hasChapter) &&
+            (identical(other.hasQuiz, hasQuiz) || other.hasQuiz == hasQuiz));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, bookId, title, bookCover, pubDate, author, publisher);
+  int get hashCode => Object.hash(runtimeType, bookId, title, bookCover,
+      pubDate, author, publisher, alreadyExists, hasChapter, hasQuiz);
 
   @override
   String toString() {
-    return 'LikeBookResponse(bookId: $bookId, title: $title, bookCover: $bookCover, pubDate: $pubDate, author: $author, publisher: $publisher)';
+    return 'LikeBookResponse(bookId: $bookId, title: $title, bookCover: $bookCover, pubDate: $pubDate, author: $author, publisher: $publisher, alreadyExists: $alreadyExists, hasChapter: $hasChapter, hasQuiz: $hasQuiz)';
   }
 }
 
@@ -375,7 +466,10 @@ abstract mixin class _$LikeBookResponseCopyWith<$Res>
       String bookCover,
       String pubDate,
       String author,
-      String publisher});
+      String publisher,
+      bool alreadyExists,
+      bool hasChapter,
+      bool hasQuiz});
 }
 
 /// @nodoc
@@ -397,6 +491,9 @@ class __$LikeBookResponseCopyWithImpl<$Res>
     Object? pubDate = null,
     Object? author = null,
     Object? publisher = null,
+    Object? alreadyExists = null,
+    Object? hasChapter = null,
+    Object? hasQuiz = null,
   }) {
     return _then(_LikeBookResponse(
       bookId: null == bookId
@@ -423,6 +520,18 @@ class __$LikeBookResponseCopyWithImpl<$Res>
           ? _self.publisher
           : publisher // ignore: cast_nullable_to_non_nullable
               as String,
+      alreadyExists: null == alreadyExists
+          ? _self.alreadyExists
+          : alreadyExists // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasChapter: null == hasChapter
+          ? _self.hasChapter
+          : hasChapter // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasQuiz: null == hasQuiz
+          ? _self.hasQuiz
+          : hasQuiz // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }

--- a/lib/modules/book_pick/model/like_book_response.g.dart
+++ b/lib/modules/book_pick/model/like_book_response.g.dart
@@ -14,6 +14,9 @@ _LikeBookResponse _$LikeBookResponseFromJson(Map<String, dynamic> json) =>
       pubDate: json['pubDate'] as String? ?? '',
       author: json['author'] as String? ?? '',
       publisher: json['publisher'] as String? ?? '',
+      alreadyExists: json['alreadyExists'] as bool? ?? false,
+      hasChapter: json['hasChapter'] as bool? ?? false,
+      hasQuiz: json['hasQuiz'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$LikeBookResponseToJson(_LikeBookResponse instance) =>
@@ -24,4 +27,7 @@ Map<String, dynamic> _$LikeBookResponseToJson(_LikeBookResponse instance) =>
       'pubDate': instance.pubDate,
       'author': instance.author,
       'publisher': instance.publisher,
+      'alreadyExists': instance.alreadyExists,
+      'hasChapter': instance.hasChapter,
+      'hasQuiz': instance.hasQuiz,
     };

--- a/lib/modules/book_pick/model/search_book_response.dart
+++ b/lib/modules/book_pick/model/search_book_response.dart
@@ -12,6 +12,9 @@ abstract class SearchBookResponse with _$SearchBookResponse {
     @Default('') String pubDate,
     @Default('') String author,
     @Default('') String publisher,
+    @Default(false) bool alreadyExists,
+    @Default(false) bool hasChapter,
+    @Default(false) bool hasQuiz,
   }) = _SearchBookResponse;
 
   factory SearchBookResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/modules/book_pick/model/search_book_response.freezed.dart
+++ b/lib/modules/book_pick/model/search_book_response.freezed.dart
@@ -20,6 +20,9 @@ mixin _$SearchBookResponse {
   String get pubDate;
   String get author;
   String get publisher;
+  bool get alreadyExists;
+  bool get hasChapter;
+  bool get hasQuiz;
 
   /// Create a copy of SearchBookResponse
   /// with the given fields replaced by the non-null parameter values.
@@ -44,17 +47,22 @@ mixin _$SearchBookResponse {
             (identical(other.pubDate, pubDate) || other.pubDate == pubDate) &&
             (identical(other.author, author) || other.author == author) &&
             (identical(other.publisher, publisher) ||
-                other.publisher == publisher));
+                other.publisher == publisher) &&
+            (identical(other.alreadyExists, alreadyExists) ||
+                other.alreadyExists == alreadyExists) &&
+            (identical(other.hasChapter, hasChapter) ||
+                other.hasChapter == hasChapter) &&
+            (identical(other.hasQuiz, hasQuiz) || other.hasQuiz == hasQuiz));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, bookId, title, bookCover, pubDate, author, publisher);
+  int get hashCode => Object.hash(runtimeType, bookId, title, bookCover,
+      pubDate, author, publisher, alreadyExists, hasChapter, hasQuiz);
 
   @override
   String toString() {
-    return 'SearchBookResponse(bookId: $bookId, title: $title, bookCover: $bookCover, pubDate: $pubDate, author: $author, publisher: $publisher)';
+    return 'SearchBookResponse(bookId: $bookId, title: $title, bookCover: $bookCover, pubDate: $pubDate, author: $author, publisher: $publisher, alreadyExists: $alreadyExists, hasChapter: $hasChapter, hasQuiz: $hasQuiz)';
   }
 }
 
@@ -70,7 +78,10 @@ abstract mixin class $SearchBookResponseCopyWith<$Res> {
       String bookCover,
       String pubDate,
       String author,
-      String publisher});
+      String publisher,
+      bool alreadyExists,
+      bool hasChapter,
+      bool hasQuiz});
 }
 
 /// @nodoc
@@ -92,6 +103,9 @@ class _$SearchBookResponseCopyWithImpl<$Res>
     Object? pubDate = null,
     Object? author = null,
     Object? publisher = null,
+    Object? alreadyExists = null,
+    Object? hasChapter = null,
+    Object? hasQuiz = null,
   }) {
     return _then(_self.copyWith(
       bookId: null == bookId
@@ -118,6 +132,18 @@ class _$SearchBookResponseCopyWithImpl<$Res>
           ? _self.publisher
           : publisher // ignore: cast_nullable_to_non_nullable
               as String,
+      alreadyExists: null == alreadyExists
+          ? _self.alreadyExists
+          : alreadyExists // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasChapter: null == hasChapter
+          ? _self.hasChapter
+          : hasChapter // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasQuiz: null == hasQuiz
+          ? _self.hasQuiz
+          : hasQuiz // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -215,16 +241,32 @@ extension SearchBookResponsePatterns on SearchBookResponse {
 
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
-    TResult Function(int bookId, String title, String bookCover, String pubDate,
-            String author, String publisher)?
+    TResult Function(
+            int bookId,
+            String title,
+            String bookCover,
+            String pubDate,
+            String author,
+            String publisher,
+            bool alreadyExists,
+            bool hasChapter,
+            bool hasQuiz)?
         $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
       case _SearchBookResponse() when $default != null:
-        return $default(_that.bookId, _that.title, _that.bookCover,
-            _that.pubDate, _that.author, _that.publisher);
+        return $default(
+            _that.bookId,
+            _that.title,
+            _that.bookCover,
+            _that.pubDate,
+            _that.author,
+            _that.publisher,
+            _that.alreadyExists,
+            _that.hasChapter,
+            _that.hasQuiz);
       case _:
         return orElse();
     }
@@ -245,15 +287,31 @@ extension SearchBookResponsePatterns on SearchBookResponse {
 
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(int bookId, String title, String bookCover, String pubDate,
-            String author, String publisher)
+    TResult Function(
+            int bookId,
+            String title,
+            String bookCover,
+            String pubDate,
+            String author,
+            String publisher,
+            bool alreadyExists,
+            bool hasChapter,
+            bool hasQuiz)
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _SearchBookResponse():
-        return $default(_that.bookId, _that.title, _that.bookCover,
-            _that.pubDate, _that.author, _that.publisher);
+        return $default(
+            _that.bookId,
+            _that.title,
+            _that.bookCover,
+            _that.pubDate,
+            _that.author,
+            _that.publisher,
+            _that.alreadyExists,
+            _that.hasChapter,
+            _that.hasQuiz);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -273,15 +331,31 @@ extension SearchBookResponsePatterns on SearchBookResponse {
 
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(int bookId, String title, String bookCover,
-            String pubDate, String author, String publisher)?
+    TResult? Function(
+            int bookId,
+            String title,
+            String bookCover,
+            String pubDate,
+            String author,
+            String publisher,
+            bool alreadyExists,
+            bool hasChapter,
+            bool hasQuiz)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _SearchBookResponse() when $default != null:
-        return $default(_that.bookId, _that.title, _that.bookCover,
-            _that.pubDate, _that.author, _that.publisher);
+        return $default(
+            _that.bookId,
+            _that.title,
+            _that.bookCover,
+            _that.pubDate,
+            _that.author,
+            _that.publisher,
+            _that.alreadyExists,
+            _that.hasChapter,
+            _that.hasQuiz);
       case _:
         return null;
     }
@@ -297,7 +371,10 @@ class _SearchBookResponse implements SearchBookResponse {
       this.bookCover = '',
       this.pubDate = '',
       this.author = '',
-      this.publisher = ''});
+      this.publisher = '',
+      this.alreadyExists = false,
+      this.hasChapter = false,
+      this.hasQuiz = false});
   factory _SearchBookResponse.fromJson(Map<String, dynamic> json) =>
       _$SearchBookResponseFromJson(json);
 
@@ -319,6 +396,15 @@ class _SearchBookResponse implements SearchBookResponse {
   @override
   @JsonKey()
   final String publisher;
+  @override
+  @JsonKey()
+  final bool alreadyExists;
+  @override
+  @JsonKey()
+  final bool hasChapter;
+  @override
+  @JsonKey()
+  final bool hasQuiz;
 
   /// Create a copy of SearchBookResponse
   /// with the given fields replaced by the non-null parameter values.
@@ -347,17 +433,22 @@ class _SearchBookResponse implements SearchBookResponse {
             (identical(other.pubDate, pubDate) || other.pubDate == pubDate) &&
             (identical(other.author, author) || other.author == author) &&
             (identical(other.publisher, publisher) ||
-                other.publisher == publisher));
+                other.publisher == publisher) &&
+            (identical(other.alreadyExists, alreadyExists) ||
+                other.alreadyExists == alreadyExists) &&
+            (identical(other.hasChapter, hasChapter) ||
+                other.hasChapter == hasChapter) &&
+            (identical(other.hasQuiz, hasQuiz) || other.hasQuiz == hasQuiz));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, bookId, title, bookCover, pubDate, author, publisher);
+  int get hashCode => Object.hash(runtimeType, bookId, title, bookCover,
+      pubDate, author, publisher, alreadyExists, hasChapter, hasQuiz);
 
   @override
   String toString() {
-    return 'SearchBookResponse(bookId: $bookId, title: $title, bookCover: $bookCover, pubDate: $pubDate, author: $author, publisher: $publisher)';
+    return 'SearchBookResponse(bookId: $bookId, title: $title, bookCover: $bookCover, pubDate: $pubDate, author: $author, publisher: $publisher, alreadyExists: $alreadyExists, hasChapter: $hasChapter, hasQuiz: $hasQuiz)';
   }
 }
 
@@ -375,7 +466,10 @@ abstract mixin class _$SearchBookResponseCopyWith<$Res>
       String bookCover,
       String pubDate,
       String author,
-      String publisher});
+      String publisher,
+      bool alreadyExists,
+      bool hasChapter,
+      bool hasQuiz});
 }
 
 /// @nodoc
@@ -397,6 +491,9 @@ class __$SearchBookResponseCopyWithImpl<$Res>
     Object? pubDate = null,
     Object? author = null,
     Object? publisher = null,
+    Object? alreadyExists = null,
+    Object? hasChapter = null,
+    Object? hasQuiz = null,
   }) {
     return _then(_SearchBookResponse(
       bookId: null == bookId
@@ -423,6 +520,18 @@ class __$SearchBookResponseCopyWithImpl<$Res>
           ? _self.publisher
           : publisher // ignore: cast_nullable_to_non_nullable
               as String,
+      alreadyExists: null == alreadyExists
+          ? _self.alreadyExists
+          : alreadyExists // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasChapter: null == hasChapter
+          ? _self.hasChapter
+          : hasChapter // ignore: cast_nullable_to_non_nullable
+              as bool,
+      hasQuiz: null == hasQuiz
+          ? _self.hasQuiz
+          : hasQuiz // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }

--- a/lib/modules/book_pick/model/search_book_response.g.dart
+++ b/lib/modules/book_pick/model/search_book_response.g.dart
@@ -14,6 +14,9 @@ _SearchBookResponse _$SearchBookResponseFromJson(Map<String, dynamic> json) =>
       pubDate: json['pubDate'] as String? ?? '',
       author: json['author'] as String? ?? '',
       publisher: json['publisher'] as String? ?? '',
+      alreadyExists: json['alreadyExists'] as bool? ?? false,
+      hasChapter: json['hasChapter'] as bool? ?? false,
+      hasQuiz: json['hasQuiz'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$SearchBookResponseToJson(_SearchBookResponse instance) =>
@@ -24,4 +27,7 @@ Map<String, dynamic> _$SearchBookResponseToJson(_SearchBookResponse instance) =>
       'pubDate': instance.pubDate,
       'author': instance.author,
       'publisher': instance.publisher,
+      'alreadyExists': instance.alreadyExists,
+      'hasChapter': instance.hasChapter,
+      'hasQuiz': instance.hasQuiz,
     };

--- a/lib/modules/book_pick/view_model/book_pick_search_view_model.dart
+++ b/lib/modules/book_pick/view_model/book_pick_search_view_model.dart
@@ -46,8 +46,8 @@ class BookPickSearchViewModel extends _$BookPickSearchViewModel {
   Future<BookPickSearchState> refreshLikeBooks() async {
     final prev = state.value ?? BookPickSearchState();
     if (prev.likeBook.nextCursor != -1) {
-      final responseLike =
-          await _bookPickRepository.getMyLikes(cursorId: prev.likeBook.nextCursor, title: prev.likeBook.title);
+      final responseLike = await _bookPickRepository.getMyLikes(
+          cursorId: prev.likeBook.nextCursor, title: prev.likeBook.title);
       state = AsyncValue.data(prev.copyWith(
         likeBook: prev.likeBook.copyWith(
           likeBooks: [...prev.likeBook.likeBooks, ...responseLike.data.data],

--- a/lib/modules/book_pick/view_model/search_book_view_model.dart
+++ b/lib/modules/book_pick/view_model/search_book_view_model.dart
@@ -65,16 +65,11 @@ class SearchBookViewModel extends _$SearchBookViewModel {
     }
   }
 
-  Future<(int, bool, bool, bool)> createChallenges(int bookId) async {
+  Future<int> createChallenges(int bookId) async {
     // 책의 모든 챕터 퀴즈 일괄 생성(비동기)
     // await searchBookRepository.generateAllQuizzes(bookId);
     // 목차 기반 챌린지 생성
     final response = await searchBookRepository.createChallenges(bookId);
-    return (
-      response.data.challengeId,
-      response.data.alreadyExists,
-      response.data.hasChapter,
-      response.data.hasQuiz,
-    );
+    return response.data.challengeId;
   }
 }

--- a/lib/modules/reading_challenge/view/screens/reading_challenge_search_new_my_likes_screen.dart
+++ b/lib/modules/reading_challenge/view/screens/reading_challenge_search_new_my_likes_screen.dart
@@ -102,31 +102,37 @@ class _ReadingChallengeSearchNewMyLikesScreenState
                   pubDate: likeBook.pubDate,
                   author: likeBook.author,
                   publisher: likeBook.publisher,
+                  alreadyExists: likeBook.alreadyExists,
+                  hasChapter: likeBook.hasChapter,
+                  hasQuiz: likeBook.hasQuiz,
                 );
                 return BookSearchResultCard(
                     book: book,
                     onTap: () async {
-                      // 챌린지가 존재하지 않으면 다음 화면으로 이동
-                      final (challengeId, alreadyExists, hasChapter, hasQuiz) =
-                          await notifier.createChallenges(book.bookId);
-                      if (alreadyExists) {
+                      if (book.alreadyExists) {
                         OverlayUtils.showCustomToast(
                             context, '이미 진행중인 챌린지입니다.');
-                      } else if (!hasChapter) {
+                      } else if (!book.hasChapter) {
                         OverlayUtils.showCustomToast(context, '이 책은 목차가 없습니다.');
                       } else {
-                        if (!hasQuiz) {
+                        if (!book.hasQuiz) {
                           final result = await showDialog(
                               context: context,
                               builder: (_) {
                                 return ReadingChallengeHasQuizDialog();
                               });
                           if (result != null && result) {
+                            // 챌린지가 존재하지 않으면 다음 화면으로 이동
+                            final challengeId =
+                                await notifier.createChallenges(book.bookId);
                             if (!context.mounted) return;
                             context.go("/reading-challenge",
                                 extra: {"challengeId": challengeId});
                           }
                         } else {
+                          // 챌린지가 존재하지 않으면 다음 화면으로 이동
+                          final challengeId =
+                              await notifier.createChallenges(book.bookId);
                           if (!context.mounted) return;
                           context.go("/reading-challenge",
                               extra: {"challengeId": challengeId});

--- a/lib/modules/reading_challenge/view/screens/reading_challenge_search_new_screen.dart
+++ b/lib/modules/reading_challenge/view/screens/reading_challenge_search_new_screen.dart
@@ -113,32 +113,31 @@ class _ReadingChallengeSearchNewScreenState
                       hasNext: data.hasNext,
                       scrollController: scrollController,
                       onTapItem: (book) async {
-                        // 챌린지가 존재하지 않으면 다음 화면으로 이동
-                        final (
-                          challengeId,
-                          alreadyExists,
-                          hasChapter,
-                          hasQuiz
-                        ) = await notifier.createChallenges(book.bookId);
-                        if (alreadyExists) {
+                        if (book.alreadyExists) {
                           OverlayUtils.showCustomToast(
                               context, '이미 진행중인 챌린지입니다.');
-                        } else if (!hasChapter) {
+                        } else if (!book.hasChapter) {
                           OverlayUtils.showCustomToast(
                               context, '이 책은 목차가 없습니다.');
                         } else {
-                          if (!hasQuiz) {
+                          if (!book.hasQuiz) {
                             final result = await showDialog(
                                 context: context,
                                 builder: (_) {
                                   return ReadingChallengeHasQuizDialog();
                                 });
                             if (result != null && result) {
+                              // 챌린지가 존재하지 않으면 다음 화면으로 이동
+                              final challengeId =
+                                  await notifier.createChallenges(book.bookId);
                               if (!context.mounted) return;
                               context.go("/reading-challenge",
                                   extra: {"challengeId": challengeId});
                             }
                           } else {
+                            // 챌린지가 존재하지 않으면 다음 화면으로 이동
+                            final challengeId =
+                                await notifier.createChallenges(book.bookId);
                             if (!context.mounted) return;
                             context.go("/reading-challenge",
                                 extra: {"challengeId": challengeId});


### PR DESCRIPTION
Fixes #222

## Summary
책 검색 및 좋아요 API 응답에 챌린지 생성 가능 여부를 사전에 확인할 수 있는 속성을 추가하여, POST api/v3/challenges 호출 전 검증을 수행하도록 개선했습니다.

## Changes
- **SearchBookResponse 모델 확장**
  - alreadyExists, hasChapter, hasQuiz 속성 추가
  - Freezed, JSON 직렬화 파일 자동 생성

- **LikeBookResponse 모델 확장**
  - alreadyExists, hasChapter, hasQuiz 속성 추가
  - Freezed, JSON 직렬화 파일 자동 생성

- **SearchBookViewModel 로직 개선**
  - createChallenges 메서드 반환 타입 단순화 (튜플 → int)
  - 챌린지 생성 가능 여부는 API 응답으로 사전 확인

- **챌린지 검색 화면 UX 개선**
  - ReadingChallengeSearchNewScreen
  - ReadingChallengeSearchNewMyLikesScreen
  - API 응답의 속성을 활용하여 POST 전 검증:
    - `alreadyExists`: 이미 진행중인 챌린지 확인
    - `hasChapter`: 목차 존재 여부 확인
    - `hasQuiz`: 퀴즈 존재 여부 확인 후 다이얼로그 표시

## Test Plan
- [ ] 알라딘 책 검색 시 alreadyExists/hasChapter/hasQuiz 값이 정상 반영되는지 확인
- [ ] 좋아요한 책 목록에서 alreadyExists/hasChapter/hasQuiz 값이 정상 반영되는지 확인
- [ ] 이미 진행중인 챌린지 선택 시 토스트 메시지 표시 확인
- [ ] 목차가 없는 책 선택 시 토스트 메시지 표시 확인
- [ ] 퀴즈가 없는 책 선택 시 다이얼로그 표시 확인
- [ ] 모든 조건을 만족하는 책 선택 시 챌린지 시작 화면 이동 확인

<!-- 필요 시 스크린샷 추가 -->
| Before | After |
|--------|-------|
|  |  |

🤖 Generated with [Claude Code](https://claude.com/claude-code)