### PR TITLE
#235 리딩챌린지: 건너뛴 목차 알림 기능 추가

### DIFF
--- a/lib/modules/reading_challenge/view/screens/reading_challenge_start_screen.dart
+++ b/lib/modules/reading_challenge/view/screens/reading_challenge_start_screen.dart
@@ -1,5 +1,6 @@
 import 'package:bookstar/common/components/base_screen.dart';
 import 'package:bookstar/common/components/button/cta_button_l1.dart';
+import 'package:bookstar/common/components/dialog/custom_dialog.dart';
 import 'package:bookstar/common/theme/style/app_texts.dart';
 import 'package:bookstar/gen/assets.gen.dart';
 import 'package:bookstar/gen/colors.gen.dart';
@@ -40,16 +41,52 @@ class _ReadingChallengeStartScreenState
     }
   }
 
-  _onTapChapter(int chapterId) {
-    setState(() {
-      _selectedChapterId = chapterId;
-    });
+  _onTapChapter(int chapterId) async {
+    if (_targetChapter?.chapterId == chapterId) {
+      setState(() {
+        _selectedChapterId = chapterId;
+      });
+    } else {
+      final result = await showDialog(
+          context: context,
+          builder: (context) {
+            return CustomDialog(
+              title: '잠시만요!',
+              content: '"${_targetChapter?.title}"를 읽지 않았어요.\n 건너뛰고 진행할까요?',
+              titleStyle: AppTexts.b7.copyWith(color: ColorName.w1),
+              contentStyle: AppTexts.b11.copyWith(color: ColorName.g2),
+              icon:
+                  Assets.icons.icDeepTimeGoToQuiz.svg(width: 100, height: 100),
+              onCancel: () {
+                Navigator.of(context).pop(false);
+              },
+              onConfirm: () {
+                Navigator.of(context).pop(true);
+              },
+              confirmButtonText: '계속하기',
+              cancelButtonText: '취소',
+            );
+          });
+
+      if (result != null && result) {
+        setState(() {
+          _selectedChapterId = chapterId;
+        });
+      }
+    }
   }
+
+  ChallengeDetailChapter? get _targetChapter => ref
+      .watch(challengeStartViewModelProvider(widget.challengeId))
+      .value
+      ?.detail
+      .chapters
+      .firstWhereOrNull((element) => element.status == ChapterStatus.LOCKED);
 
   @override
   PreferredSizeWidget? buildAppBar(BuildContext context) {
     return AppBar(
-      title: const Text('리딩챌린지'),
+      title: Text('리딩챌린지'),
       leading: IconButton(
         icon: const BackButton(),
         onPressed: () => Navigator.of(context).pop(),
@@ -80,6 +117,12 @@ class _ReadingChallengeStartScreenState
                       chapters: data.detail.chapters,
                       onTapItem: (chapterId) {
                         _onTapChapter(chapterId);
+                      },
+                      onTapTargetChapter: () {
+                        if (_targetChapter != null) {
+                          _onTapChapter(_targetChapter!.chapterId);
+                          goToQuizScreen();
+                        }
                       },
                       selectedChapterId: _selectedChapterId),
                   if (_selectedChapterId != null)
@@ -225,13 +268,29 @@ class _ReadingChallengeStartScreenState
   Widget _buildChaptersSection(
       {required List<ChallengeDetailChapter> chapters,
       required Function(int) onTapItem,
+      required Function onTapTargetChapter,
       required int? selectedChapterId}) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          "목차",
-          style: AppTexts.b1.copyWith(color: ColorName.w1),
+        GestureDetector(
+          onTap: () => onTapTargetChapter(),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                "오늘의 목차 바로 읽기 📖",
+                style: AppTexts.b1.copyWith(color: ColorName.w1),
+              ),
+              SizedBox(
+                width: 4,
+              ),
+              Icon(
+                Icons.arrow_forward_ios,
+                size: 16,
+              ),
+            ],
+          ),
         ),
         SizedBox(
           height: 16,

--- a/lib/modules/reading_challenge/view/screens/reading_challenge_start_screen.dart
+++ b/lib/modules/reading_challenge/view/screens/reading_challenge_start_screen.dart
@@ -28,6 +28,7 @@ class ReadingChallengeStartScreen extends BaseScreen {
 class _ReadingChallengeStartScreenState
     extends BaseScreenState<ReadingChallengeStartScreen> {
   int? _selectedChapterId;
+  // bool _isShowWarningDialog = false;
 
   @override
   void onInitState() {
@@ -42,11 +43,11 @@ class _ReadingChallengeStartScreenState
   }
 
   _onTapChapter(int chapterId) async {
-    if (_targetChapter?.chapterId == chapterId) {
+    if (_targetChapter?.chapterId == chapterId || _isSkippedTargetChapter) {
       setState(() {
         _selectedChapterId = chapterId;
       });
-    } else {
+    } else if (!_isSkippedTargetChapter) {
       final result = await showDialog(
           context: context,
           builder: (context) {
@@ -82,6 +83,30 @@ class _ReadingChallengeStartScreenState
       ?.detail
       .chapters
       .firstWhereOrNull((element) => element.status == ChapterStatus.LOCKED);
+
+  int get _targetChapterIndex =>
+      ref
+          .watch(challengeStartViewModelProvider(widget.challengeId))
+          .value
+          ?.detail
+          .chapters
+          .indexWhere((element) => element.status == ChapterStatus.LOCKED) ??
+      -1;
+  bool get _isSkippedTargetChapter {
+    final chapters = ref
+        .watch(challengeStartViewModelProvider(widget.challengeId))
+        .value
+        ?.detail
+        .chapters;
+
+    if (chapters == null) return false;
+    if (_targetChapterIndex == -1) return false;
+    if (_targetChapterIndex == chapters.length - 1) return false;
+
+    return chapters
+        .skip(_targetChapterIndex + 1)
+        .any((element) => element.status != ChapterStatus.LOCKED);
+  }
 
   @override
   PreferredSizeWidget? buildAppBar(BuildContext context) {
@@ -124,6 +149,8 @@ class _ReadingChallengeStartScreenState
                           goToQuizScreen();
                         }
                       },
+                      isSkippedTargetChapter: _isSkippedTargetChapter,
+                      targetChapterTitle: _targetChapter?.title ?? "",
                       selectedChapterId: _selectedChapterId),
                   if (_selectedChapterId != null)
                     SizedBox(
@@ -269,37 +296,50 @@ class _ReadingChallengeStartScreenState
       {required List<ChallengeDetailChapter> chapters,
       required Function(int) onTapItem,
       required Function onTapTargetChapter,
+      required bool isSkippedTargetChapter,
+      required String targetChapterTitle,
       required int? selectedChapterId}) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        GestureDetector(
-          onTap: () => onTapTargetChapter(),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Text(
-                "오늘의 목차 바로 읽기 📖",
-                style: AppTexts.b1.copyWith(color: ColorName.w1),
-              ),
-              SizedBox(
-                width: 4,
-              ),
-              Icon(
-                Icons.arrow_forward_ios,
-                size: 16,
-              ),
-            ],
+        if (isSkippedTargetChapter)
+          GestureDetector(
+            onTap: () => onTapTargetChapter(),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      "건너뛴 목차 읽기 📖",
+                      style: AppTexts.b8.copyWith(color: ColorName.g2),
+                    ),
+                    SizedBox(
+                      width: 4,
+                    ),
+                    Icon(
+                      Icons.arrow_forward_ios,
+                      size: 16,
+                    ),
+                  ],
+                ),
+                Text(
+                  targetChapterTitle,
+                  style: AppTexts.b1.copyWith(color: ColorName.w1),
+                  overflow: TextOverflow.ellipsis,
+                )
+              ],
+            ),
           ),
-        ),
         SizedBox(
           height: 16,
         ),
         Column(
           spacing: 12,
           children: chapters
-              .map(
-                (chapter) => GestureDetector(
+              .mapIndexed(
+                (index, chapter) => GestureDetector(
                   onTap: () {
                     if (chapter.status == ChapterStatus.COMPLETED) return;
                     onTapItem(chapter.chapterId);
@@ -330,6 +370,11 @@ class _ReadingChallengeStartScreenState
                                     crossAxisAlignment:
                                         CrossAxisAlignment.start,
                                     children: [
+                                      Text(
+                                        "목차 ${index + 1}",
+                                        style: AppTexts.b8
+                                            .copyWith(color: ColorName.g3),
+                                      ),
                                       Text(
                                         chapter.title,
                                         style: AppTexts.b5


### PR DESCRIPTION
Fixes #235

## Summary
리딩챌린지 시작 화면에서 사용자가 목차를 건너뛴 경우 건너뛴 목차를 알려주는 기능을 추가했습니다.

## 주요 변경사항
- **건너뛴 목차 감지 로직 구현**
  - `_isSkippedTargetChapter`: 목표 챕터 이후에 완료된 챕터가 있는지 확인
  - `_targetChapterIndex`: 현재 목표 챕터(LOCKED 상태)의 인덱스 반환
- **건너뛴 목차 바로 읽기 UI 추가**
  - 건너뛴 목차가 있을 때 "건너뛴 목차 읽기 📖" 섹션 표시
  - 건너뛴 목차의 제목을 명시적으로 표시하여 사용자가 쉽게 인지 가능
- **챕터 선택 로직 개선**
  - 건너뛴 목차가 있을 때는 목표 챕터를 바로 선택 가능하도록 수정
  - 건너뛴 목차가 없을 때만 순차 진행 안내 다이얼로그 표시
- **목차 리스트 UI 개선**
  - 각 목차에 "목차 N" 라벨 추가하여 목차 순서를 명확히 표시
  - `mapIndexed`를 활용하여 인덱스 기반 렌더링으로 개선

## 기술적 세부사항
- `_onTapChapter` 메서드 수정: 건너뛴 목차 여부에 따라 다른 동작 수행
- 목차 목록 렌더링 시 `mapIndexed` 사용으로 인덱스 정보 활용
- 챕터 상태(ChapterStatus)를 기반으로 건너뛴 목차 여부 판단

<!-- 필요 시 스크린샷 추가 -->
| Before | After |
|--------|-------|
|  |  |